### PR TITLE
Always restore Android notifications with a minimum date of now

### DIFF
--- a/src/android/Restore.java
+++ b/src/android/Restore.java
@@ -54,6 +54,16 @@ public class Restore extends BroadcastReceiver {
         for (String alarmId : alarmIds) {
             try {
                 JSONArray args  = new JSONArray(alarms.getString(alarmId, ""));
+                
+                /* If this notification was registered for a time when the
+                 * device was off then change the date to now to ensure that no
+                 * notifications are missed
+                 */
+                Date now = new Date();
+                if (now.after(new Date(args.optLong("date") * 1000))) {
+                    args.put("date", (now.getTime() / 1000));
+                }
+
                 Options options = new Options(context).parse(args.getJSONObject(0));
 
                 LocalNotification.add(options);


### PR DESCRIPTION
This change prevents missing a notification that was scheduled to fire when the device was off by re-registering it for right now. This matches the behaviour on iOS.

Fixes #38.
