### PR TITLE
Fix missing Date import in Restore.java

### DIFF
--- a/src/android/Restore.java
+++ b/src/android/Restore.java
@@ -22,6 +22,7 @@
 package de.appplant.cordova.plugin.localnotification;
 
 import java.util.Set;
+import java.util.Date;
 
 import org.json.JSONArray;
 import org.json.JSONException;


### PR DESCRIPTION
```
[javac] .../platforms/android/src/de/appplant/cordova/plugin/localnotification/Restore.java:62: cannot find symbol
[javac] symbol  : class Date
[javac] location: class de.appplant.cordova.plugin.localnotification.Restore
[javac]                 Date now = new Date();
[javac]                 ^
[javac] .../platforms/android/src/de/appplant/cordova/plugin/localnotification/Restore.java:62: cannot find symbol
[javac] symbol  : class Date
[javac] location: class de.appplant.cordova.plugin.localnotification.Restore
[javac]                 Date now = new Date();
[javac]                                ^
[javac] .../platforms/android/src/de/appplant/cordova/plugin/localnotification/Restore.java:63: cannot find symbol
[javac] symbol  : class Date
[javac] location: class de.appplant.cordova.plugin.localnotification.Restore
[javac]                 if (now.after(new Date(args.optLong("date") * 1000))) {
[javac]                                   ^
[javac] .../platforms/android/src/de/appplant/cordova/plugin/localnotification/Restore.java:63: cannot find symbol
[javac] symbol  : method optLong(java.lang.String)
[javac] location: class org.json.JSONArray
[javac]                 if (now.after(new Date(args.optLong("date") * 1000))) {
[javac]                                            ^
[javac] .../platforms/android/src/de/appplant/cordova/plugin/localnotification/Restore.java:64: cannot find symbol
[javac] symbol  : method put(java.lang.String,int)
[javac] location: class org.json.JSONArray
[javac]                     args.put("date", (now.getTime() / 1000));
[javac]                         ^
```
