### PR TITLE
Adding in big text style for notifications on Android. 

### DIFF
--- a/src/android/Receiver.java
+++ b/src/android/Receiver.java
@@ -128,7 +128,9 @@ public class Receiver extends BroadcastReceiver {
             .setSmallIcon(options.getSmallIcon())
             .setLargeIcon(icon)
             .setAutoCancel(options.getAutoCancel())
-            .setOngoing(options.getOngoing());
+            .setOngoing(options.getOngoing())
+            .setStyle(new Notification.BigTextStyle()
+                .bigText(options.getMessage()));
 
         if (sound != null) {
             notification.setSound(sound);


### PR DESCRIPTION
At the moment the user is limited to very short notification messages, having the bigText style allows the user to drag down the notification to read more on their Android 4 and above device.
