### PR TITLE
Clearing notifications Android

### DIFF
--- a/src/android/LocalNotification.java
+++ b/src/android/LocalNotification.java
@@ -121,6 +121,16 @@ public class LocalNotification extends CordovaPlugin {
 
             return true;
         }
+        
+        if(action.equalsIgnoreCase("clearall")){
+        	clearAll();
+        	return true;
+        }
+        if(action.equalsIgnoreCase("clear")){
+        	String id = args.optString(0);
+        	clear(id);
+        	return true;
+        }
 
         // Returning false results in a "MethodNotFound" error.
         return false;
@@ -170,13 +180,10 @@ public class LocalNotification extends CordovaPlugin {
 
         PendingIntent pi       = PendingIntent.getBroadcast(context, 0, intent, PendingIntent.FLAG_CANCEL_CURRENT);
         AlarmManager am        = getAlarmManager();
-        NotificationManager nc = getNotificationManager();
 
         am.cancel(pi);
 
-        try {
-            nc.cancel(Integer.parseInt(notificationId));
-        } catch (Exception e) {}
+        clear(notificationId);
 
         fireEvent("cancel", notificationId, "");
     }
@@ -191,15 +198,42 @@ public class LocalNotification extends CordovaPlugin {
      */
     public static void cancelAll() {
         SharedPreferences settings = getSharedPreferences();
-        NotificationManager nc     = getNotificationManager();
         Map<String, ?> alarms      = settings.getAll();
         Set<String> alarmIds       = alarms.keySet();
 
         for (String alarmId : alarmIds) {
             cancel(alarmId);
         }
-
-        nc.cancelAll();
+        clearAll();
+    }
+    
+    /**
+     * Clear all notifications that were created by this plugin.
+     * 
+     * This will not remove future pending alarms.  It will only 
+     * clear alarms that are in the notification area.
+     * 
+     */
+    public static void clearAll(){
+    	NotificationManager nc     = getNotificationManager();
+    	nc.cancelAll();
+    }
+    
+    /**
+     * Clear notification that was created by this plugin.
+     * 
+     * This will not remove future pending alarms.  It will only 
+     * clear alarms that are in the notification area.
+     * 
+     * @param id
+     *          The notification ID to be check.
+     * 
+     */
+    public static void clear(String id){
+    	NotificationManager nc = getNotificationManager();
+    	try {
+            nc.cancel(Integer.parseInt(id));
+        } catch (Exception e) {}
     }
 
     /**

--- a/www/local-notification.js
+++ b/www/local-notification.js
@@ -167,6 +167,34 @@ LocalNotification.prototype = {
     isScheduled: function (id, callback) {
         cordova.exec(callback, null, 'LocalNotification', 'isScheduled', [id.toString()]);
     },
+    /**
+     * @async
+     * 
+     * Clears notification from notification area.
+     * Does not cancel future notifications.
+     * 
+     * @param {String} id
+     * 
+     */
+    
+    clear: function(id, callback){
+    	if(['Android'].indexOf(device.platform)){
+    		cordova.exec(callback, null, 'LocalNotification', 'clear', [id.toString()]);
+    	}
+    },
+    
+    /**
+     * @async
+     * 
+     * Clears all notification from notification area.
+     * Does not cancel future notifications.
+     * 
+     */
+    clearall: function(callback){
+    	if(['Android'].indexOf(device.platform)){
+    		cordova.exec(callback, null, 'LocalNotification', 'clearall', [id.toString()]);
+    	}
+    },
 
     /**
      * Occurs when a notification was added.


### PR DESCRIPTION
Support for clearing notifications (all or by id) from notification bar
without canceling notifications scheduled in the future.