### PR TITLE
Update to LocalNotification.cancel()

### DIFF
--- a/src/android/LocalNotification.java
+++ b/src/android/LocalNotification.java
@@ -186,7 +186,7 @@ public class LocalNotification extends CordovaPlugin {
         Intent intent = new Intent(context, Receiver.class)
             .setAction("" + notificationId);
 
-        PendingIntent pi       = PendingIntent.getBroadcast(context, 0, intent, PendingIntent.FLAG_CANCEL_CURRENT);
+        PendingIntent pi       = PendingIntent.getBroadcast(context, 0, intent, 0);
         AlarmManager am        = getAlarmManager();
         NotificationManager nc = getNotificationManager();
 


### PR DESCRIPTION
Based on this answer from CommonsWare http://stackoverflow.com/a/16340703/2163901

When canceling a PendingIntent, there's no need to pass in extra flags to PendingIntent.getBroadcast. When you pass the flag in, the PendingIntent is not really cancelled. This can be confirmed by using the dumpsys utility as such: adb shell dumpsys alarm.
