### PR TITLE
Convert the id value to a String before comparison

### DIFF
--- a/src/ios/APPLocalNotification.m
+++ b/src/ios/APPLocalNotification.m
@@ -568,7 +568,7 @@
 
     for (UILocalNotification* notification in notifications)
     {
-        NSString* notId = [notification.userInfo objectForKey:@"id"];
+        NSString* notId = [[notification.userInfo objectForKey:@"id"] stringValue];
 
         if ([notId isEqualToString:id]) {
             return notification;


### PR DESCRIPTION
When trying to use the plugin on ios to display a simple local notification, i.e.

```
window.plugin.notification.local.add({
    id: "1",
    message: "test",
    title: "Hello"
});
```

The application throws the following exception

```
*** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '-[__NSCFNumber isEqualToString:]: unrecognized selector sent to instance 0x17d7b4b0'
```

It appears that ios is returning the id as an Integer, so the quick and dirty fix would be to cast to a String before comparing.
