### PR TITLE
IOS: If notification is fired with date now or in the past, fire immediately

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 ## ChangeLog
+
+#### Version 0.7.5 (29.10.2014)
+- [enhancement:] __iOS8 Support__
+- [feature:] New method `hasPermission` to ask if the user has granted to display local notifications.
+- [feature:] New method `promptForPermission` to promt the user to grant permission to display local notifications.
+
 #### Version 0.7.4 (22.03.2014)
 - [bugfix:] Platform specific properties were ignored.
 - [bugfix:] `cancel` may throw an error if the OS returns NIL values (iOS).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## ChangeLog
 
+#### Version 0.7.6 (03.10.2014)
+- [bugfix:] `hasPermission` and `promptForPermission` let the app crash on iOS7 and older.
+- [bugfix:] Convert the id value to a String before comparison.
+- [bugfix:] Prevent possible crash when calling `cancelAll`.
+- [enhancement:] Do not inherit any notification defaults.
+
 #### Version 0.7.5 (29.09.2014)
 - [enhancement:] __iOS8 Support__
 - [feature:] New method `hasPermission` to ask if the user has granted to display local notifications.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## ChangeLog
 
-#### Version 0.7.5 (29.10.2014)
+#### Version 0.7.5 (29.09.2014)
 - [enhancement:] __iOS8 Support__
 - [feature:] New method `hasPermission` to ask if the user has granted to display local notifications.
 - [feature:] New method `promptForPermission` to promt the user to grant permission to display local notifications.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## ChangeLog
-#### Version 0.7.4 (not yet released)
+#### Version 0.7.4 (22.03.2014)
 - [bugfix:] Platform specific properties were ignored.
 - [bugfix:] `cancel` may throw an error if the OS returns NIL values (iOS).
 - [bugfix:] Replacing a notification with the same ID may result into canceling both (iOS).

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The purpose of the plugin is to create an platform independent javascript interf
 
 
 ## Supported Platforms
-- **iOS**<br>
+- **iOS** *(including iOS8)*<br>
 See [Local and Push Notification Programming Guide][ios_notification_guide] for detailed informations and screenshots.
 
 - **Android** *(SDK >=11)*<br>
@@ -42,12 +42,12 @@ The plugin can either be installed into the local development environment or clo
 Through the [Command-line Interface][CLI]:
 ```bash
 # ~~ from master ~~
-cordova plugin add https://github.com/katzer/cordova-plugin-local-notifications.git && cordova prepare
+cordova plugin add https://github.com/katzer/cordova-plugin-local-notifications.git
 ```
 or to use the last stable version:
 ```bash
 # ~~ stable version ~~
-cordova plugin add de.appplant.cordova.plugin.local-notification && cordova prepare
+cordova plugin add de.appplant.cordova.plugin.local-notification@0.7.5
 ```
 
 ### Removing the Plugin from your project
@@ -63,9 +63,20 @@ Add the following xml to your config.xml to always use the latest version of thi
 ```
 or to use an specific version:
 ```xml
-<gap:plugin name="de.appplant.cordova.plugin.local-notification" version="0.7.2" />
+<gap:plugin name="de.appplant.cordova.plugin.local-notification" version="0.7.5" />
 ```
 More informations can be found [here][PGB_plugin].
+
+
+## ChangeLog
+
+#### Version 0.7.5 (29.10.2014)
+- [enhancement:] __iOS8 Support__
+- [feature:] New method `hasPermission` to ask if the user has granted to display local notifications.
+- [feature:] New method `promptForPermission` to promt the user to grant permission to display local notifications.
+
+#### Further informations
+- See [CHANGELOG.md][changelog] to get the full changelog for the plugin.
 
 
 ## Using the plugin
@@ -80,6 +91,30 @@ document.addEventListener('deviceready', function () {
 }, false);
 ```
 
+### Determine if the app does have the permission to show local notifications
+If the permission has been granted through the user can be retrieved through the `notification.badge.hasPermission` interface.<br/>
+The method takes a callback function as its argument which will be called with a boolean value. Optional the scope of the callback function ca be defined through a second argument.
+
+#### Further informations
+- The method is supported on each platform, however its only relevant for iOS8 and above.
+
+```javascript
+window.plugin.notification.local.hasPermission(function (granted) {
+    // console.log('Permission has been granted: ' + granted);
+});
+```
+
+### Prompt the user to grant permission for local notifications
+The user can be prompted to grant the required permission through the `notification.badge.promptForPermission` interface.
+
+#### Further informations
+- The method is supported on each platform, however its only relevant for iOS8 and above.
+- The user will only get a prompt dialog for the first time. Later its only possible to change the setting via the notification center.
+
+```javascript
+window.plugin.notification.local.promptForPermission();
+```
+
 ### Schedule local notifications
 Local notifications can be scheduled through the `notification.local.add` interface.<br>
 The method takes a hash as an argument to specify the notification's properties and returns the ID for the notification.<br>
@@ -90,6 +125,7 @@ All properties are optional. If no date object is given, the notification pops-u
 If the ID has an invalid format, it will be ignored, but canceling the notification will fail.
 
 #### Further informations
+- The notification can only be sheduled if the user has previously granted the [required permission][prompt_permission].
 - See the [onadd][onadd] event of how a listener can be registered to be notified when a local notification has been scheduled.
 - See the [ontrigger][ontrigger] event of how a listener can be registered to be notified when a local notification has been triggered.
 - See the [onclick][onclick] event of how a listener can be registered to be notified when the user has been clicked on a local notification.
@@ -267,6 +303,8 @@ window.plugin.notification.local.add({
     date:    _60_seconds_from_now
 });
 ```
+
+__Note:__ The notification can only be sheduled if the user has granted the [required permission][prompt_permission].
 
 ### Scheduling an immediately triggered local notification
 The example below shows how to schedule a local notification which will be triggered immediatly.
@@ -448,6 +486,9 @@ This software is released under the [Apache 2.0 License](http://opensource.org/l
 [CLI]: http://cordova.apache.org/docs/en/3.0.0/guide_cli_index.md.html#The%20Command-line%20Interface
 [PGB]: http://docs.build.phonegap.com/en_US/3.3.0/index.html
 [PGB_plugin]: https://build.phonegap.com/plugins/413
+[changelog]: CHANGELOG.md
+[has_permission]: #determine-if-the-app-does-have-the-permission-to-show-local-notifications
+[prompt_permission]: #prompt-the-user-to-grant-permission-for-local-notifications
 [onadd]: #get-notified-when-a-local-notification-has-been-scheduled
 [onclick]: #get-notified-when-the-user-has-been-clicked-on-a-local-notification
 [oncancel]: #get-notified-when-a-local-notification-has-been-canceled

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ document.addEventListener('deviceready', function () {
 ```
 
 ### Determine if the app does have the permission to show local notifications
-If the permission has been granted through the user can be retrieved through the `notification.badge.hasPermission` interface.<br/>
+If the permission has been granted through the user can be retrieved through the `notification.local.hasPermission` interface.<br/>
 The method takes a callback function as its argument which will be called with a boolean value. Optional the scope of the callback function ca be defined through a second argument.
 
 #### Further informations
@@ -105,7 +105,7 @@ window.plugin.notification.local.hasPermission(function (granted) {
 ```
 
 ### Prompt the user to grant permission for local notifications
-The user can be prompted to grant the required permission through the `notification.badge.promptForPermission` interface.
+The user can be prompted to grant the required permission through the `notification.local.promptForPermission` interface.
 
 #### Further informations
 - The method is supported on each platform, however its only relevant for iOS8 and above.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ cordova plugin add https://github.com/katzer/cordova-plugin-local-notifications.
 or to use the last stable version:
 ```bash
 # ~~ stable version ~~
-cordova plugin add de.appplant.cordova.plugin.local-notification@0.7.5
+cordova plugin add de.appplant.cordova.plugin.local-notification@0.7.6
 ```
 
 ### Removing the Plugin from your project
@@ -63,7 +63,7 @@ Add the following xml to your config.xml to always use the latest version of thi
 ```
 or to use an specific version:
 ```xml
-<gap:plugin name="de.appplant.cordova.plugin.local-notification" version="0.7.5" />
+<gap:plugin name="de.appplant.cordova.plugin.local-notification" version="0.7.6" />
 ```
 More informations can be found [here][PGB_plugin].
 
@@ -491,7 +491,7 @@ This software is released under the [Apache 2.0 License](http://opensource.org/l
 [apache_device_plugin]: https://github.com/apache/cordova-plugin-device
 [CLI]: http://cordova.apache.org/docs/en/3.0.0/guide_cli_index.md.html#The%20Command-line%20Interface
 [PGB]: http://docs.build.phonegap.com/en_US/3.3.0/index.html
-[PGB_plugin]: https://build.phonegap.com/plugins/1124
+[PGB_plugin]: https://build.phonegap.com/plugins/1196
 [changelog]: CHANGELOG.md
 [has_permission]: #determine-if-the-app-does-have-the-permission-to-show-local-notifications
 [prompt_permission]: #prompt-the-user-to-grant-permission-for-local-notifications

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ More informations can be found [here][PGB_plugin].
 
 ## ChangeLog
 
-#### Version 0.7.5 (29.10.2014)
+#### Version 0.7.5 (29.09.2014)
 - [enhancement:] __iOS8 Support__
 - [feature:] New method `hasPermission` to ask if the user has granted to display local notifications.
 - [feature:] New method `promptForPermission` to promt the user to grant permission to display local notifications.
@@ -125,7 +125,7 @@ All properties are optional. If no date object is given, the notification pops-u
 If the ID has an invalid format, it will be ignored, but canceling the notification will fail.
 
 #### Further informations
-- The notification can only be sheduled if the user has previously granted the [required permission][prompt_permission].
+- The notification can only be scheduled if the user has previously granted the [required permission][prompt_permission].
 - See the [onadd][onadd] event of how a listener can be registered to be notified when a local notification has been scheduled.
 - See the [ontrigger][ontrigger] event of how a listener can be registered to be notified when a local notification has been triggered.
 - See the [onclick][onclick] event of how a listener can be registered to be notified when the user has been clicked on a local notification.
@@ -304,7 +304,7 @@ window.plugin.notification.local.add({
 });
 ```
 
-__Note:__ The notification can only be sheduled if the user has granted the [required permission][prompt_permission].
+__Note:__ The notification can only be scheduled if the user has granted the [required permission][prompt_permission].
 
 ### Scheduling an immediately triggered local notification
 The example below shows how to schedule a local notification which will be triggered immediatly.

--- a/README.md
+++ b/README.md
@@ -70,6 +70,12 @@ More informations can be found [here][PGB_plugin].
 
 ## ChangeLog
 
+#### Version 0.7.6 (03.10.2014)
+- [bugfix:] `hasPermission` and `promptForPermission` let the app crash on iOS7 and older.
+- [bugfix:] Convert the id value to a String before comparison.
+- [bugfix:] Prevent possible crash when calling `cancelAll`.
+- [enhancement:] Do not inherit any notification defaults.
+
 #### Version 0.7.5 (29.09.2014)
 - [enhancement:] __iOS8 Support__
 - [feature:] New method `hasPermission` to ask if the user has granted to display local notifications.

--- a/README.md
+++ b/README.md
@@ -485,7 +485,7 @@ This software is released under the [Apache 2.0 License](http://opensource.org/l
 [apache_device_plugin]: https://github.com/apache/cordova-plugin-device
 [CLI]: http://cordova.apache.org/docs/en/3.0.0/guide_cli_index.md.html#The%20Command-line%20Interface
 [PGB]: http://docs.build.phonegap.com/en_US/3.3.0/index.html
-[PGB_plugin]: https://build.phonegap.com/plugins/413
+[PGB_plugin]: https://build.phonegap.com/plugins/1124
 [changelog]: CHANGELOG.md
 [has_permission]: #determine-if-the-app-does-have-the-permission-to-show-local-notifications
 [prompt_permission]: #prompt-the-user-to-grant-permission-for-local-notifications

--- a/plugin.xml
+++ b/plugin.xml
@@ -3,7 +3,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android"
         id="de.appplant.cordova.plugin.local-notification"
-        version="0.7.5">
+        version="0.7.6">
 
     <name>LocalNotification</name>
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -3,7 +3,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android"
         id="de.appplant.cordova.plugin.local-notification"
-        version="0.7.4dev">
+        version="0.7.4">
 
     <name>LocalNotification</name>
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -3,7 +3,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android"
         id="de.appplant.cordova.plugin.local-notification"
-        version="0.7.4">
+        version="0.7.5-dev">
 
     <name>LocalNotification</name>
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -3,12 +3,12 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android"
         id="de.appplant.cordova.plugin.local-notification"
-        version="0.7.5-dev">
+        version="0.7.5">
 
     <name>LocalNotification</name>
 
     <description>A bunch of local-notification plugins for Cordova 3.x.x</description>
-    <repo>https://github.com/katzer/cordova-plugin-local-notifications.git</repo>
+    <repo>https://github.com/katzer/cordova-plugin-local-notifications/tree/0.7</repo>
     <keywords>notification, local notification, alarm, scheduler, tile, live tiles, ios, android, windows phone 8, wp8, iOS8</keywords>
     <license>Apache 2.0</license>
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -9,7 +9,7 @@
 
     <description>A bunch of local-notification plugins for Cordova 3.x.x</description>
     <repo>https://github.com/katzer/cordova-plugin-local-notifications.git</repo>
-    <keywords>notification, local notification, alarm, scheduler, tile, live tiles, ios, android, windows phone 8, wp8</keywords>
+    <keywords>notification, local notification, alarm, scheduler, tile, live tiles, ios, android, windows phone 8, wp8, iOS8</keywords>
     <license>Apache 2.0</license>
 
     <author>Sebastián Katzer</author>

--- a/src/android/LocalNotification.java
+++ b/src/android/LocalNotification.java
@@ -120,6 +120,15 @@ public class LocalNotification extends CordovaPlugin {
             return true;
         }
 
+        if (action.equalsIgnoreCase("hasPermission")) {
+            hasPermission(callbackContext);
+            return true;
+        }
+
+        if (action.equalsIgnoreCase("promptForPermission")) {
+            return true;
+        }
+
         if (action.equalsIgnoreCase("deviceready")) {
             cordova.getThreadPool().execute( new Runnable() {
                 public void run() {
@@ -263,6 +272,25 @@ public class LocalNotification extends CordovaPlugin {
         JSONArray pendingIds       = new JSONArray(alarmIds);
 
         callbackContext.success(pendingIds);
+    }
+
+    /**
+     * Informs if the app has the permission to show notifications.
+     *
+     * @param callback
+     *      The function to be exec as the callback
+     */
+    private void hasPermission (final CallbackContext callback) {
+        cordova.getThreadPool().execute(new Runnable() {
+            @Override
+            public void run() {
+                PluginResult result;
+
+                result = new PluginResult(PluginResult.Status.OK, true);
+
+                callback.sendPluginResult(result);
+            }
+        });
     }
 
     /**

--- a/src/android/Receiver.java
+++ b/src/android/Receiver.java
@@ -122,6 +122,7 @@ public class Receiver extends BroadcastReceiver {
         Uri sound   = options.getSound();
 
         Builder notification = new Notification.Builder(context)
+            .setDefaults(0) // Do not inherit any defaults
 	        .setContentTitle(options.getTitle())
 	        .setContentText(options.getMessage())
 	        .setNumber(options.getBadge())
@@ -130,7 +131,7 @@ public class Receiver extends BroadcastReceiver {
 	        .setLargeIcon(icon)
 	        .setAutoCancel(options.getAutoCancel())
 	        .setOngoing(options.getOngoing());
-        
+
         if (sound != null) {
         	notification.setSound(sound);
         }
@@ -139,7 +140,7 @@ public class Receiver extends BroadcastReceiver {
         	notification.setStyle(new Notification.BigTextStyle()
         		.bigText(options.getMessage()));
         }
-        
+
         setClickEvent(notification);
 
         return notification;

--- a/src/ios/APPLocalNotification.h
+++ b/src/ios/APPLocalNotification.h
@@ -36,5 +36,9 @@
 - (void) isScheduled:(CDVInvokedUrlCommand*)command;
 // Retrieves a list of ids from all currently pending notifications
 - (void) getScheduledIds:(CDVInvokedUrlCommand*)command;
+// Informs if the app has the permission to show notifications
+- (void) hasPermission:(CDVInvokedUrlCommand *)command;
+// Ask for permission to show notifications
+- (void) promptForPermission:(CDVInvokedUrlCommand *)command;
 
 @end

--- a/src/ios/APPLocalNotification.m
+++ b/src/ios/APPLocalNotification.m
@@ -210,6 +210,67 @@
 }
 
 /**
+ * Informs if the app has the permission to show
+ * badges and local notifications.
+ *
+ * @param callback
+ *      The function to be exec as the callback
+ */
+- (void) hasPermission:(CDVInvokedUrlCommand *)command
+{
+    [self.commandDelegate runInBackground:^{
+        CDVPluginResult* result;
+        BOOL hasPermission = [self hasPermissionToSheduleNotifications];
+
+        result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK
+                                     messageAsBool:hasPermission];
+
+        [self.commandDelegate sendPluginResult:result
+                                    callbackId:command.callbackId];
+    }];
+}
+
+/**
+ * Ask for permission to show badges.
+ *
+ * @param callback
+ *      The function to be exec as the callback
+ */
+- (void) promptForPermission:(CDVInvokedUrlCommand *)command
+{
+#ifdef __IPHONE_8_0
+    UIUserNotificationType types =
+    UIUserNotificationTypeAlert|UIUserNotificationTypeBadge|UIUserNotificationTypeSound;
+
+    UIUserNotificationSettings *settings = [UIUserNotificationSettings settingsForTypes:types
+                                                                             categories:nil];
+
+    [self.commandDelegate runInBackground:^{
+        [[UIApplication sharedApplication]
+         registerUserNotificationSettings:settings];
+    }];
+#endif
+}
+
+/**
+ * If the app has the permission to show badges.
+ */
+- (BOOL) hasPermissionToSheduleNotifications
+{
+#ifdef __IPHONE_8_0
+    UIUserNotificationSettings *settings = [[UIApplication sharedApplication]
+                                                currentUserNotificationSettings];
+
+    UIUserNotificationType requiredTypes =
+    UIUserNotificationTypeAlert|UIUserNotificationTypeBadge|UIUserNotificationTypeSound;
+
+    return (settings.types & requiredTypes);
+#else
+    return YES;
+#endif
+}
+
+/**
  * Schedules a new local notification and fies the coresponding event.
  *
  * @param {NSMutableDictionary} properties

--- a/src/ios/APPLocalNotification.m
+++ b/src/ios/APPLocalNotification.m
@@ -102,11 +102,14 @@
         NSArray* arguments = [command arguments];
         NSMutableDictionary* properties = [arguments objectAtIndex:0];
 
+        UILocalNotification* notification;
         NSString* id = [properties objectForKey:@"id"];
 
         if ([self isNotificationScheduledWithId:id]) {
-            UILocalNotification* notification = [self notificationWithId:id];
+            notification = [self notificationWithId:id];
+        }
 
+        if (notification) {
             dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 0.3 * NSEC_PER_SEC),
                            dispatch_get_main_queue(), ^{
                                [self cancelNotification:notification fireEvent:NO];
@@ -576,7 +579,8 @@
 
     for (UILocalNotification* notification in notifications)
     {
-        NSString* notId = [notification.userInfo objectForKey:@"id"];
+        NSString* notId = [[notification.userInfo objectForKey:@"id"]
+                           stringValue];
 
         if ([notId isEqualToString:id]) {
             return notification;

--- a/src/ios/APPLocalNotification.m
+++ b/src/ios/APPLocalNotification.m
@@ -20,6 +20,7 @@
  */
 
 #import "APPLocalNotification.h"
+#import <Cordova/CDVAvailability.h>
 
 @interface APPLocalNotification (Private)
 
@@ -108,8 +109,8 @@
 
             dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 0.3 * NSEC_PER_SEC),
                            dispatch_get_main_queue(), ^{
-                [self cancelNotification:notification fireEvent:NO];
-            });
+                               [self cancelNotification:notification fireEvent:NO];
+                           });
         }
 
         [self scheduleNotificationWithProperties:properties];
@@ -238,12 +239,14 @@
  */
 - (void) promptForPermission:(CDVInvokedUrlCommand *)command
 {
-    if ([[[UIDevice currentDevice] systemVersion] floatValue] >= 8.0) {
-        UIUserNotificationType types =
-        UIUserNotificationTypeAlert|UIUserNotificationTypeBadge|UIUserNotificationTypeSound;
+    if (IsAtLeastiOSVersion(@"8.0")) {
+        UIUserNotificationType types;
+        UIUserNotificationSettings *settings;
 
-        UIUserNotificationSettings *settings = [UIUserNotificationSettings settingsForTypes:types
-                                                                                 categories:nil];
+        types = UIUserNotificationTypeAlert|UIUserNotificationTypeBadge|UIUserNotificationTypeSound;
+
+        settings = [UIUserNotificationSettings settingsForTypes:types
+                                                     categories:nil];
 
         [self.commandDelegate runInBackground:^{
             [[UIApplication sharedApplication]
@@ -257,14 +260,16 @@
  */
 - (BOOL) hasPermissionToSheduleNotifications
 {
-    if ([[[UIDevice currentDevice] systemVersion] floatValue] >= 8.0) {
-        UIUserNotificationSettings *settings = [[UIApplication sharedApplication]
-                                                    currentUserNotificationSettings];
+    if (IsAtLeastiOSVersion(@"8.0")) {
+        UIUserNotificationType types;
+        UIUserNotificationSettings *settings;
 
-        UIUserNotificationType requiredTypes =
-        UIUserNotificationTypeAlert|UIUserNotificationTypeBadge|UIUserNotificationTypeSound;
+        settings = [[UIApplication sharedApplication]
+                    currentUserNotificationSettings];
 
-        return (settings.types & requiredTypes);
+        types = UIUserNotificationTypeAlert|UIUserNotificationTypeBadge|UIUserNotificationTypeSound;
+
+        return (settings.types & types);
     } else {
         return YES;
     }

--- a/src/ios/APPLocalNotification.m
+++ b/src/ios/APPLocalNotification.m
@@ -579,8 +579,8 @@
 
     for (UILocalNotification* notification in notifications)
     {
-        NSString* notId = [[notification.userInfo objectForKey:@"id"]
-                           stringValue];
+        //String value here crashes app
+        NSString* notId = [notification.userInfo objectForKey:@"id"];
 
         if ([notId isEqualToString:id]) {
             return notification;

--- a/src/wp8/LocalNotification.cs
+++ b/src/wp8/LocalNotification.cs
@@ -132,6 +132,26 @@ namespace Cordova.Extension.Commands
             DispatchCommandResult();
         }
 
+        /// <summery>
+        /// Informs if the app has the permission to show notifications.
+        /// </summery>
+        public void hasPermission(string args)
+        {
+            PluginResult result;
+
+            result = new PluginResult(PluginResult.Status.OK, true);
+
+            DispatchCommandResult(result);
+        }
+
+        /// <summery>
+        /// Ask for permission to show notifications.
+        /// </summery>
+        public void promptForPermission(string args)
+        {
+            DispatchCommandResult();
+        }
+
         /// <summary>
         /// Informs that the device is ready and the deviceready event has been fired
         /// </summary>

--- a/www/local-notification.js
+++ b/www/local-notification.js
@@ -169,6 +169,29 @@ LocalNotification.prototype = {
     },
 
     /**
+     * Informs if the app has the permission to show badges.
+     *
+     * @param {Function} callback
+     *      The function to be exec as the callback
+     * @param {Object?} scope
+     *      The callback function's scope
+     */
+    hasPermission: function (callback, scope) {
+        var fn = function (badge) {
+            callback.call(scope || this, badge);
+        };
+
+        cordova.exec(fn, null, 'LocalNotification', 'hasPermission', []);
+    },
+
+    /**
+     * Ask for permission to show badges if not already granted.
+     */
+    promptForPermission: function () {
+        cordova.exec(null, null, 'LocalNotification', 'promptForPermission', []);
+    },
+
+    /**
      * Occurs when a notification was added.
      *
      * @param {String} id    The ID of the notification


### PR DESCRIPTION
The Local Notifications plugin uses the function:
```m
[[UIApplication sharedApplication]
         scheduleLocalNotification:notification];
```
To schedule a notification. However, I was finding that it did not work reliably for notifications that you want to be displayed "right now"... This could happen, for instance, if you're doing background geolocation, and you want to display a local notification.

This commit looks at the fireDate for a notification, and if it is for this second, or in the past, then it will use the method presentLocalNotificationNow to display it.