### PR TITLE
Only try to ask user permission if device is running iOS 8 or above. Fix crash.

### DIFF
--- a/src/ios/APPLocalNotification.m
+++ b/src/ios/APPLocalNotification.m
@@ -247,7 +247,7 @@
  */
 - (void) promptForPermission:(CDVInvokedUrlCommand *)command
 {
-    if isNotiOS8() return;
+    if ([self isNotiOS8]) return;
 
     UIUserNotificationType types =
     UIUserNotificationTypeAlert|UIUserNotificationTypeBadge|UIUserNotificationTypeSound;
@@ -266,7 +266,7 @@
  */
 - (BOOL) hasPermissionToSheduleNotifications
 {
-    if isNotiOS8() return YES;
+    if ([self isNotiOS8]) return YES;
 
     UIUserNotificationSettings *settings = [[UIApplication sharedApplication]
                                                 currentUserNotificationSettings];


### PR DESCRIPTION
Only try to ask user permission is device is running iOS 8 or above. Fix crash when asking a user for notification permission on versions below iOS 8.

Previously, if this method was called on a non iOS 8 device, the app crashed. Please see: https://github.com/katzer/cordova-plugin-local-notifications/issues/261

This way the permission is only called on devices that are running iOS 8 or greater.
