### PR TITLE
Edit README to fix grammar and standardize English

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,18 +15,18 @@ Local notifications are ideally suited for applications with time-based behavior
 For example, applications that depend on servers for messages or data can poll their servers for incoming items while running in the background; if a message is ready to view or an update is ready to download, they can then present a local notification immediately to inform their users.
 
 ### Plugin's Purpose
-The purpose of the plugin is to create an platform independent javascript interface for [Cordova][cordova] based mobile applications to access the specific API on each platform.
+The purpose of the plugin is to create a platform-independent javascript interface for [Cordova][cordova]-based mobile applications to access the specific API on each platform.
 
 
 ## Supported Platforms
 - **iOS** _(up to iOS8)_<br>
-See [Local and Push Notification Programming Guide][ios_notification_guide] for detailed informations and screenshots.
+See [Local and Push Notification Programming Guide][ios_notification_guide] for detailed information and screenshots.
 
 - **Android** *(SDK >=7)*<br>
-See [Notification Guide][android_notification_guide] for detailed informations and screenshots.
+See [Notification Guide][android_notification_guide] for detailed information and screenshots.
 
 - **WP8**<br>
-See [Local notifications for Windows Phone][wp8_notification_guide] for detailed informations and screenshots.
+See [Local notifications for Windows Phone][wp8_notification_guide] for detailed information and screenshots.
 <br>*Windows Phone 8.0 has no notification center. Instead local notifications are realized through live tiles updates.*
 
 
@@ -65,7 +65,7 @@ or to use an specific version:
 ```xml
 <gap:plugin name="de.appplant.cordova.plugin.local-notification" version="0.7.2" />
 ```
-More informations can be found [here][PGB_plugin].
+More information can be found [here][PGB_plugin].
 
 
 ## ChangeLog
@@ -80,7 +80,7 @@ More informations can be found [here][PGB_plugin].
 - [enhancement:] Callbacks for `add`, `cancel` & `cancelAll`
 - [enhancement:] `image:` accepts remote URLs and local URIs (Android)
 
-#### Further informations
+#### Further information
 - See [CHANGELOG.md][changelog] to get the full changelog for the plugin.
 - See the [v0.8.x TODO List][todo_list] for upcomming changes and other things.
 
@@ -113,11 +113,11 @@ document.addEventListener('deviceready', function () {
 ```
 
 ### Determine if the app does have the permission to show local notifications
-If the permission has been granted through the user can be retrieved through the `notification.local.hasPermission` interface.<br/>
-The method takes a callback function as its argument which will be called with a boolean value. Optional the scope of the callback function ca be defined through a second argument.
+If the permission has been granted through the user it can be retrieved through the `notification.local.hasPermission` interface.<br/>
+The method takes a callback function as its argument which will be called with a boolean value. Optional: the scope of the callback function can be defined through a second argument.
 
-#### Further informations
-- The method is supported on each platform, however its only relevant for iOS8 and above.
+#### Further information
+- The method is supported on each platform, however it's only relevant for iOS8 and above.
 
 ```javascript
 window.plugin.notification.local.hasPermission(function (granted) {
@@ -128,9 +128,9 @@ window.plugin.notification.local.hasPermission(function (granted) {
 ### Register permission for local notifications
 Required permissions can be registered through the `notification.local.registerPermission` interface.
 
-#### Further informations
+#### Further information
 - The method is supported on each platform, however its only relevant for iOS8 and above.
-- The user will only get a prompt dialog for the first time. Later its only possible to change the setting via the notification center.
+- The user will only get a prompt dialog for the first time. Later it's only possible to change the setting via the notification center.
 
 ```javascript
 window.plugin.notification.local.registerPermission();
@@ -139,23 +139,23 @@ window.plugin.notification.local.registerPermission();
 ### Schedule local notifications
 Local notifications can be scheduled through the `notification.local.add` interface.<br>
 The method takes a hash as an argument to specify the notification's properties and returns the ID for the notification.<br>
-Scheduling a local notification will override the previously one with the same ID.
+Scheduling a local notification will override an earlier one with the same ID.
 All properties are optional. If no date object is given, the notification pops-up immediately.
 
 **Note:** On Android the notification id needs to be a string which can be converted to a number.
-If the ID has an invalid format, it will be ignored, but canceling the notification will fail.
+If the ID has an invalid format, it will be ignored, but cancelling the notification will fail.
 
-#### Further informations
-- See the [onadd][onadd] event of how a listener can be registered to be notified when a local notification has been scheduled.
-- See the [ontrigger][ontrigger] event of how a listener can be registered to be notified when a local notification has been triggered.
-- See the [onclick][onclick] event of how a listener can be registered to be notified when the user has been clicked on a local notification.
-- See the [platform specific properties][platform_specific_properties] of which other properties are available too.
-- See [getDefaults][getdefaults] of which property values are used by default and [setDefaults][setdefaults] of how to override them.
-- See the [examples][examples] of how to schedule local notifications.
+#### Further information
+- See the [onadd][onadd] event for registering a listener to be notified when a local notification has been scheduled.
+- See the [ontrigger][ontrigger] event for registering a listener to be notified when a local notification has been triggered.
+- See the [onclick][onclick] event for registering a listener to be notified when the user has been clicked on a local notification.
+- See the [platform specific properties][platform_specific_properties] too list which other properties are available too.
+- See [getDefaults][getdefaults] to examine which property values are used by default and [setDefaults][setdefaults] how to override them.
+- See [examples][examples] for scheduling local notifications.
 
 ```javascript
 window.plugin.notification.local.add({
-    id:         String,  // A unique id of the notifiction
+    id:         String,  // A unique id of the notification
     date:       Date,    // This expects a date object
     message:    String,  // The message that is displayed
     title:      String,  // The title of the message
@@ -163,44 +163,44 @@ window.plugin.notification.local.add({
     badge:      Number,  // Displays number badge to notification
     sound:      String,  // A sound to be played
     json:       String,  // Data to be passed through the notification
-    autoCancel: Boolean, // Setting this flag and the notification is automatically canceled when the user clicks it
+    autoCancel: Boolean, // Setting this flag and the notification is automatically cancelled when the user clicks it
     ongoing:    Boolean, // Prevent clearing of notification (Android only)
 }, callback, scope);
 ```
 
 ### Cancel scheduled local notifications
-Local notifications can be canceled through the `notification.local.cancel` interface.<br>
-Note that only local notifications with an ID can be canceled.
+Local notifications can be cancelled through the `notification.local.cancel` interface.<br>
+Note that only local notifications with an ID can be cancelled.
 
-#### Further informations
-- See the [oncancel][oncancel] event of how a listener can be registered to be notified when a local notification has been canceled.
-- See [getScheduledIds][getscheduledids] of how to retrieve a list of IDs of all scheduled local notifications.
+#### Further information
+- See the [oncancel][oncancel] event for registering a listener to be notified when a local notification has been cancelled.
+- See [getScheduledIds][getscheduledids] to retrieve a list of IDs for all scheduled local notifications.
 
 ```javascript
 window.plugin.notification.local.cancel(ID, function () {
-    // The notification has been canceled
+    // The notification has been cancelled
 }, scope);
 ```
 
 ### Cancel all scheduled local notifications
-All local notifications can be canceled through the `notification.local.cancelAll` interface.<br>
+All local notifications can be cancelled through the `notification.local.cancelAll` interface.<br>
 The method cancels all local notifications even if they have no ID.
 
-#### Further informations
-- See the [oncancel][oncancel] event of how a listener can be registered to be notified when a local notification has been canceled.
+#### Further information
+- See the [oncancel][oncancel] event for registering a listener to be notified when a local notification has been cancelled.
 
 ```javascript
 window.plugin.notification.local.cancelAll(function () {
-    // All notifications have been canceled
+    // All notifications have been cancelled
 }, scope);
 ```
 
-### Check wether a notification with an ID is scheduled
+### Check whether a notification with an ID is scheduled
 To check if a notification with an ID is scheduled, the `notification.local.isScheduled` interface can be used.<br>
-The method takes the ID of the local notification as an argument and a callback function to be called with the result. Optional the scope of the callback can be assigned too.
+The method takes the ID of the local notification as an argument and a callback function to be called with the result. Optional: the scope of the callback can be assigned too.
 
-#### Further informations
-- See [getScheduledIds][getscheduledids] of how to retrieve a list of IDs of all scheduled local notifications.
+#### Further information
+- See [getScheduledIds][getscheduledids] to retrieve a list of IDs for all scheduled local notifications.
 
 ```javascript
 window.plugin.notification.local.isScheduled(id, function (isScheduled) {
@@ -210,7 +210,7 @@ window.plugin.notification.local.isScheduled(id, function (isScheduled) {
 
 ### Retrieve the IDs from all currently scheduled local notifications
 To retrieve the IDs from all currently scheduled local notifications, the `notification.local.getScheduledIds` interface can be used.<br>
-The method takes a callback function to be called with the result as an array of IDs. Optional the scope of the callback can be assigned too.
+The method takes a callback function to be called with the result as an array of IDs. Optional: the scope of the callback can be assigned too.
 
 ```javascript
 window.plugin.notification.local.getScheduledIds(function (scheduledIds) {
@@ -218,12 +218,12 @@ window.plugin.notification.local.getScheduledIds(function (scheduledIds) {
 }, scope);
 ```
 
-### Check wether a notification with an ID was triggered
+### Check whether a notification with an ID was triggered
 To check if a notification with an ID was triggered, the `notification.local.isTriggered` interface can be used.<br>
-The method takes the ID of the local notification as an argument and a callback function to be called with the result. Optional the scope of the callback can be assigned too.
+The method takes the ID of the local notification as an argument and a callback function to be called with the result. Optional: the scope of the callback can be assigned too.
 
-#### Further informations
-- See [getTriggeredIds][gettriggeredIds] of how to retrieve a list of IDs of all scheduled local notifications.
+#### Further information
+- See [getTriggeredIds][gettriggeredIds] to retrieve a list of IDs for all scheduled local notifications.
 
 ```javascript
 window.plugin.notification.local.isTriggered(id, function (isTriggered) {
@@ -233,7 +233,7 @@ window.plugin.notification.local.isTriggered(id, function (isTriggered) {
 
 ### Retrieve the IDs from all currently triggered local notifications
 To retrieve the IDs from all currently triggered local notifications, the `notification.local.getTriggeredIds` interface can be used.<br>
-The method takes a callback function to be called with the result as an array of IDs. Optional the scope of the callback can be assigned too.
+The method takes a callback function to be called with the result as an array of IDs. Optional: the scope of the callback can be assigned too.
 
 ```javascript
 window.plugin.notification.local.getTriggeredIds(function (triggeredIds) {
@@ -245,8 +245,8 @@ window.plugin.notification.local.getTriggeredIds(function (triggeredIds) {
 The default values of the local notification properties can be retrieved through the `notification.local.getDefaults` interface.<br>
 The method returns an object of values for all available local notification properties on the platform.
 
-#### Further informations
-- See [setDefaults][setdefaults] of how to override the default values.
+#### Further information
+- See [setDefaults][setdefaults] to override the default values.
 
 ```javascript
 window.plugin.notification.local.getDefaults(); // => Object
@@ -256,9 +256,9 @@ window.plugin.notification.local.getDefaults(); // => Object
 The default values of the local notification properties can be set through the `notification.local.setDefaults` interface.<br>
 The method takes an object as argument.
 
-#### Further informations
+#### Further information
 - See the [add][add] interface and the [platform specific properties][platform_specific_properties] to get an overview about all available local notification properties.
-- See the [example][setdefaults_example] of how to override default values.
+- See the [example][setdefaults_example] to override default values.
 
 ```javascript
 window.plugin.notification.local.setDefaults(Object);
@@ -267,15 +267,15 @@ window.plugin.notification.local.setDefaults(Object);
 ### Get notified when a local notification has been scheduled
 The `notification.local.onadd` interface can be used to get notified when a local notification has been scheduled.
 
-The listener has to be a function and takes the following arguments:
+The listener must be a function and takes the following arguments:
  - id: The ID of the notification
  - state: Either *background* or *foreground*
  - json: A custom (JSON encoded) string
 
 **Note:** The event is only being invoked in background if the app is not suspended!
 
-#### Further informations
-- See the [ontrigger][ontrigger] event of how a listener can be registered to be notified when a local notification has been triggered.
+#### Further information
+- See the [ontrigger][ontrigger] event for registering a listener to be notified when a local notification has been triggered.
 
 ```javascript
 window.plugin.notification.local.onadd = function (id, state, json) {};
@@ -284,15 +284,15 @@ window.plugin.notification.local.onadd = function (id, state, json) {};
 ### Get notified when a local notification has been triggered
 The `notification.local.ontrigger` interface can be used to get notified when a local notification has been triggered.
 
-The listener has to be a function and takes the following arguments:
+The listener must be a function and takes the following arguments:
  - id: The ID of the notification
  - state: Either *background* or *foreground*
  - json: A custom (JSON encoded) string
 
-**Note:** The event is only being invoked in background if the app is running and is not suspended!
+**Note:** The event is only invoked in background if the app is running and is not suspended!
 
-#### Further informations
-- See the [onclick][onclick] event of how a listener can be registered to be notified when the user has been clicked on a local notification.
+#### Further information
+- See the [onclick][onclick] event for registering a listener to be notified when the user has been clicked on a local notification.
 
 ```javascript
 window.plugin.notification.local.ontrigger = function (id, state, json) {};
@@ -301,33 +301,33 @@ window.plugin.notification.local.ontrigger = function (id, state, json) {};
 ### Get notified when the user has been clicked on a local notification
 The `notification.local.onclick` interface can be used to get notified when the user has been clicked on a local notification.
 
-The listener has to be a function and takes the following arguments:
+The listener must be a function and takes the following arguments:
  - id: The ID of the notification
  - state: Either *background* or *foreground*
  - json: A custom (JSON encoded) string
 
-**Note:** The event is only being invoked in background if the app is not suspended!
+**Note:** The event is only invoked in background if the app is not suspended!
 
-#### Further informations
+#### Further information
 - The *autoCancel* property can be used to either automatically cancel the local notification or not after it has been clicked by the user.
 
 ```javascript
 window.plugin.notification.local.onclick = function (id, state, json) {};
 ```
 
-### Get notified when a local notification has been canceled
-The `notification.local.oncancel` interface can be used to get notified when a local notification has been canceled.
+### Get notified when a local notification has been cancelled
+The `notification.local.oncancel` interface can be used to get notified when a local notification has been cancelled.
 
-The listener has to be a function and takes the following arguments:
+The listener must be a function and takes the following arguments:
  - id: The ID of the notification
  - state: Either *background* or *foreground*
  - json: A custom (JSON encoded) string
 
-**Note:** The event is not being invoked if the local notification has been cleared in the notification center.
+**Note:** The event is not invoked if the local notification has been cleared in the notification center.
 
-#### Further informations
-- The *autoCancel* property can be used to either automatically cancel the local notification or not after it has been clicked by the user.
-- See [cancel][cancel] and [cancelAll][cancelall] of how to cancel local notifications manually.
+#### Further information
+- The *autoCancel* property can automatically cancel the local notification if has been clicked by the user.
+- See [cancel][cancel] and [cancelAll][cancelall] to cancel local notifications manually.
 
 ```javascript
 window.plugin.notification.local.oncancel = function (id, state, json) {};
@@ -351,22 +351,22 @@ window.plugin.notification.local.add({
 });
 ```
 
-### Scheduling an immediately triggered local notification
-The example below shows how to schedule a local notification which will be triggered immediatly.
+### Scheduling an immediately-triggered local notification
+The example below shows how to schedule a local notification which will be triggered immediately.
 
 ```javascript
 window.plugin.notification.local.add({ message: 'Great app!' });
 ```
 
 ### Schedule a silent local notification
-By default the system sound for local notifications will be used. To turn off any sound the *sound* property has to be set to *NULL*.
+By default the system sound for local notifications will be used. To turn off any sound, set the *sound* property to *NULL*.
 
 ```javascript
 window.plugin.notification.local.add({ sound: null });
 ```
 
 ### Assign user data to the notification
-If needed local notifications can be scheduled with any user data. That data can be accessed on each event listener. But cannot be modified later.
+If needed, local notifications can be scheduled with any user data. That data can be accessed on each event listener, but cannot be modified later.
 
 ```javascript
 window.plugin.notification.local.add({
@@ -391,16 +391,16 @@ window.plugin.notification.local.setDefaults({ autoCancel: true });
 ## Platform specifics
 
 ### Small and large icons on Android
-By default all notifications will display the app icon. But an specific icon can be defined through the `icon` and `smallIcon` properties.
+By default all notifications will display the app icon. A specific icon can be defined through the `icon` and `smallIcon` properties.
 
 #### Resource icons
-The following example shows how to display the `<package.name>.R.drawable.ic_launcher`icon as the notifications icon.
+The following example shows how to display the `<package.name>.R.drawable.ic_launcher`icon as the notification icon.
 
 ```javascript
 window.plugin.notification.local.add({ icon: 'ic_launcher' });
 ```
 
-See below how to use the `android.R.drawable.ic_dialog_email` icon as the notifications small icon.
+See below to use the `android.R.drawable.ic_dialog_email` icon as the notification small icon.
 
 ```javascript
 window.plugin.notification.local.add({ smallIcon: 'ic_dialog_email' });
@@ -421,13 +421,13 @@ window.plugin.notification.local.add({ icon: 'https://cordova.apache.org/images/
 ```
 
 ### Notification sound on Android
-The sound must be a absolute or relative Uri pointing to the sound file. The default sound is `RingtoneManager.TYPE_NOTIFICATION`.
+The sound must be an absolute or relative URI pointing to the sound file. The default sound is `RingtoneManager.TYPE_NOTIFICATION`.
 
 **Note:** Local sound files must be placed into the res-folder and not into the assets-folder.
 
 ```javascript
 /**
- * Plays the `beep.mp3` which has to be located in the res folder
+ * Plays the `beep.mp3` which must be located in the res folder
  */
 window.plugin.notification.local.add({ sound: 'android.resource://' + package_name + '/raw/beep' });
 
@@ -437,7 +437,7 @@ window.plugin.notification.local.add({ sound: 'android.resource://' + package_na
 window.plugin.notification.local.add({ sound: 'http://remotedomain/beep.mp3' });
 
 /**
- * Plays a sound file which has to be located in the android_assets folder
+ * Plays a sound file which must be located in the android_assets folder
  */
 window.plugin.notification.local.add({ sound: '/www/audio/beep.mp3' });
 
@@ -450,29 +450,29 @@ window.plugin.notification.local.add({ sound: 'TYPE_ALARM' });
 ### Notification sound on iOS
 You can package the audio data in an *aiff*, *wav*, or *caf* file. Then, in Xcode, add the sound file to your project as a nonlocalized resource of the application bundle. You may use the *afconvert* tool to convert sounds.
 
-**Note:** The right to play notification sounds in the notification center settings has to be granted.<br>
+**Note:** To play notification sounds, permission needs to be granted in the notification center settings.<br>
 **Note:** Custom sounds must be under 30 seconds when played. If a custom sound is over that limit, the default system sound is played instead.
 
 ```javascript
 /**
- * Plays the `beep.mp3` which has to be located in the root folder of the project
+ * Plays the `beep.mp3` which must be located in the root folder of the project
  */
 window.plugin.notification.local.add({ sound: 'beep.caf' });
 
 /**
- * Plays the `beep.mp3` which has to be located in the www folder
+ * Plays the `beep.mp3` which must located in the www folder
  */
 window.plugin.notification.local.add({ sound: 'www/sounds/beep.caf' });
 ```
 
 ### LiveTile background images on WP8
-LiveTile's have the ability to display images for different sizes. These images can be defined through the `smallImage`, `image` and `wideImage` properties.
+LiveTiles have the ability to display images for different sizes. These images can be defined through the `smallImage`, `image` and `wideImage` properties.
 
-**Note:** An image must be defined as a relative or absolute URI. They can be restored to the default ones by canceling the notification.
+**Note:** An image must be defined as a relative or absolute URI. They can be restored to default by cancelling the notification.
 
 ```javascript
 /**
- * Displays the application icon as the livetile's background image
+ * Displays the application icon as the LiveTile's background image
  */
 window.plugin.notification.local.add({ image: 'appdata:ApplicationIcon.png' })
 ```
@@ -488,7 +488,7 @@ window.plugin.notification.local.add({ repeat: 15 });
 ```
 
 ### Change the LED color on Android devices
-The LED color can be specified through the `led` property. By default the color value is white (FFFFFF). Its possible to change that value by setting another hex code.
+The LED color can be specified through the `led` property. By default the color value is white (FFFFFF). It is possible to change that value by setting another hex code.
 
 ```javascript
 window.plugin.notification.local.add({ led: 'A0FF05' });
@@ -502,16 +502,16 @@ Each application on a device is limited to 64 scheduled local notifications.<br>
 The system discards scheduled notifications in excess of this limit, keeping only the 64 notifications that will fire the soonest. Recurring notifications are treated as a single notification.
 
 ### Events aren't fired on iOS
-After deploying/replacing the app on the device via Xcode no callback for previously scheduled local notifications aren't fired.
+After deploying/replacing the app on the device via Xcode, no callback for previously scheduled local notifications are fired.
 
 ### No sound is played on iOS 7
-The right to play notification sounds in the notification center settings has to be granted.
+Users must grant permission in the notification center settings for notification sounds to be played.
 
 ### Adding a notification on WP8
-An application can only display one notification at a time. Each time a new notification has to be added, the application live tile's data will be overwritten by the new ones.
+An application can only display one notification at a time. Each time a new notification is added, the application's LiveTile data will be overwritten by the new ones.
 
 ### TypeError: Cannot read property 'currentVersion' of null
-Along with Cordova 3.2 and Windows Phone 8 the `version.bat` script has to be renamed to `version`.
+Along with Cordova 3.2 and Windows Phone 8, the `version.bat` script must be renamed to `version`.
 
 On Mac or Linux
 ```
@@ -529,7 +529,7 @@ The launch mode for the main activity has to be set to `singleInstance`
 ```
 
 ### A notification cleared by the User is still shown as Triggered on Android
-It's not possible on android, to get informed about a User clearing an applications notifications. Currently the only way to prevent that sort of behavior is, to set the "ongoing" parameter to "true" and cancel the notification during the onclick event.
+It is not possible on Android to listen for an application notification to be cleared by the user. Currently, the only way to prevent that sort of behavior is to set the "ongoing" parameter to "true" and cancel the notification during the onclick event.
 
 ## Contributing
 


### PR DESCRIPTION
Many errors were repeating, due to differences in British and American English. I standardized the README to American English:
- canceled -> cancelled
- canceling -> cancelling
- informations -> information

Remove many instances of passive/awkward voice:
Before: "See the onadd event of how a listener can be registered to be notified when a local notification has been scheduled."
After: "See the onadd event to register a listener to be notified when a local notification has been scheduled."

Misc:
Many it's and its were confused. Conjunctions were sometimes used at inappropriate times.
Fix possessive apostrophes.
Fix random spelling errors.
