### PR TITLE
fixed iOS 8.1 build fails with linker error #365

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -40,9 +40,9 @@
         <source-file src="src/ios/APPLocalNotificationOptions.m" />
 
         <header-file src="src/ios/AppDelegate+APPLocalNotification.h" />
-        <header-file src="src/ios/AppDelegate+APPLocalNotification.m" />
+        <source-file src="src/ios/AppDelegate+APPLocalNotification.m" />
 
-        <source-file src="src/ios/UIApplication+APPLocalNotification.h" />
+        <header-file src="src/ios/UIApplication+APPLocalNotification.h" />
         <source-file src="src/ios/UIApplication+APPLocalNotification.m" />
 
         <header-file src="src/ios/UILocalNotification+APPLocalNotification.h" />
@@ -65,7 +65,7 @@
              * sound and it vibrates the phone.
             -->
             <receiver android:name="de.appplant.cordova.plugin.localnotification.Receiver" />
-			
+
 			<!--
              * The delete intent receiver is triggered when the user clears a notification
 			 * manually. It unpersists the cleared notification from the shared preferences.
@@ -82,7 +82,7 @@
                     <action android:name="android.intent.action.BOOT_COMPLETED" />
                 </intent-filter>
             </receiver>
-			
+
 
             <!--
              * The receiver activity is triggered when a notification is clicked by a user.


### PR DESCRIPTION
There was a copy paste error in the plugin.xml. That's why 2 files were not compiled.