### PR TITLE
Crash at runtime with iOS older than 8.0

### DIFF
--- a/src/ios/APPLocalNotification.m
+++ b/src/ios/APPLocalNotification.m
@@ -324,10 +324,17 @@
     [self.commandDelegate runInBackground:^{
         CDVPluginResult* result;
         BOOL hasPermission;
+        NSString *reqVersion = @"8.0";
+        NSString *currVersion = [[UIDevice currentDevice] systemVersion];
+        if ([currVersion compare:reqVersion options:NSNumericSearch] != NSOrderedAscending) {
+            hasPermission = [[UIApplication sharedApplication]
+                             hasPermissionToScheduleLocalNotifications];
 
-        hasPermission = [[UIApplication sharedApplication]
-                         hasPermissionToScheduleLocalNotifications];
+        } else {
+            hasPermission = YES;
+        }
 
+        
         result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK
                                      messageAsBool:hasPermission];
 
@@ -343,12 +350,18 @@
 {
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 80000
 
-    _command = command;
-
-    [self.commandDelegate runInBackground:^{
-        [[UIApplication sharedApplication]
-         registerPermissionToScheduleLocalNotifications];
-    }];
+    NSString *reqVersion = @"8.0";
+    NSString *currVersion = [[UIDevice currentDevice] systemVersion];
+    if ([currVersion compare:reqVersion options:NSNumericSearch] != NSOrderedAscending) {
+        _command = command;
+        
+        [self.commandDelegate runInBackground:^{
+            [[UIApplication sharedApplication]
+             registerPermissionToScheduleLocalNotifications];
+        }];
+    } else {
+        [self hasPermission:command];
+    }
 #else
     [self hasPermission:command];
 #endif


### PR DESCRIPTION
Hi there !
I changed the iOS part of the plugin because it makes the apps crash when executed on iphone prior v 8.0. 
I'm a newbie with iOS and github so I hope i didn't do it to bad ;)

Bye