### PR TITLE
Warn against notification IDs that arent numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,8 +145,7 @@ The method takes a hash as an argument to specify the notification's properties 
 Scheduling a local notification will override an earlier one with the same ID.
 All properties are optional. If no date object is given, the notification pops-up immediately.
 
-**Note:** On Android the notification id needs to be a string which can be converted to a number.
-If the ID has an invalid format, it will be ignored, but cancelling the notification will fail.
+**Note:** The notification ID must be a string which can be converted to a number (that is, `isNaN()` returns false for). If the ID has an invalid format, it will silently be changed to `0` and will override an earlier one with the same ID.
 
 #### Further information
 - See the [onadd][onadd] event for registering a listener to be notified when a local notification has been scheduled.


### PR DESCRIPTION
Documentation currently says that on Android only notification ID's must be convertible to a number. However, and I found this out the hard way, the code does not reflect this.

[`local-notification.js`](https://github.com/katzer/cordova-plugin-local-notifications/blob/7f6c1ce01e3041e16c61a94f4759c0455629705e/www/local-notification.js#L650-L652), approx line 650: 

    options.id         = options.id.toString();
    // ...
    if (isNaN(options.id)) {
        options.id = this.getDefaults().id;
    }

Will convert any number string to `0`. This, combined with "Scheduling a local notification will override an earlier one with the same ID" leads to some very expected behaviour. If you're setting multiple notifications with non-numerical IDs, they'll end up being reset to 0 and just overwriting each other.

I would strongly recommend you throw an error (or at least `console.warn`ing) if the ID isnt numerical to make this more obvious.

In the mean time, this PR updates the documentation to reflect what actually happens and the pitfalls that need to be aware of.