### PR TITLE
Fixed the schedule event

### DIFF
--- a/src/android/LocalNotification.java
+++ b/src/android/LocalNotification.java
@@ -180,7 +180,10 @@ public class LocalNotification extends CordovaPlugin {
     	for (int i = 0; i < notifications.length(); i++) {
     		JSONObject options = notifications.optJSONObject(i);
 
-            getNotificationMgr().schedule(options, TriggerReceiver.class);
+            Notification notification =
+                    getNotificationMgr().schedule(options, TriggerReceiver.class);
+            
+            fireEvent("schedule", notification);
     	}
     }
 


### PR DESCRIPTION
In Android the ‘schedule’ event was not raised after scheduling one or
more tasks.