### PR TITLE
Android crash fix

### DIFF
--- a/src/android/notification/Manager.java
+++ b/src/android/notification/Manager.java
@@ -194,7 +194,9 @@ public class Manager {
         ArrayList<Integer> ids = new ArrayList<Integer>();
 
         for (String key : keys) {
-            ids.add(Integer.parseInt(key));
+            try {
+                ids.add(Integer.parseInt(key));
+            } catch (NumberFormatException ignore) {}
         }
 
         return ids;


### PR DESCRIPTION
It is possible to create notifications with IDs that are not integers. However this prevents all the group querying, and cancelling from working.  This patch doesn't entirely resolve that, but it does stop the crashing at least