### PR TITLE
Updated the location for Cordova's platforms module

### DIFF
--- a/scripts/ios/didRegisterUserNotificationSettings.js
+++ b/scripts/ios/didRegisterUserNotificationSettings.js
@@ -39,10 +39,16 @@ module.exports = function (context) {
 
     var cordova_util = context.requireCordovaModule('cordova-lib/src/cordova/util'),
         ConfigParser = context.requireCordovaModule('cordova-lib/src/configparser/ConfigParser'),
-        platforms = context.requireCordovaModule('cordova-lib/src/cordova/platforms'),
         projectRoot = cordova_util.isCordova(),
         xml = cordova_util.projectConfig(projectRoot),
         cfg = new ConfigParser(xml);
+    // Cordova moved the platforms stuff; try both locations so we'll work for new and old file layouts.
+    var platforms;
+    try {
+        platforms = context.requireCordovaModule('cordova-lib/src/cordova/platforms');
+    } catch(e) {
+        platforms = context.requireCordovaModule('cordova-lib/src/platforms/platforms');
+    }
 
     /**
      * The absolute path for the file.


### PR DESCRIPTION
Updated the post-install script for iOS to look for the platforms module
in its new location. It'll look in the previous location too, so the
plugin should work on previous versions of Cordova too.

Fix for issue #531.