### PR TITLE
Update cordova device dependency to new location

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -24,7 +24,7 @@
     </engines>
 
     <!-- dependencies -->
-    <dependency id="org.apache.cordova.device" />
+    <dependency id="cordova-plugin-device" />
 
     <!-- info -->
     <info>


### PR DESCRIPTION
This just updates the cordova device dependency to the new name as using the old one generates a warning.