### PR TITLE
Updating id of android v4 support lib to latest

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -79,7 +79,7 @@
     <!-- android -->
     <platform name="android">
 
-        <dependency id="android.support.v4" />
+        <dependency id="cordova-plugin-android-support-v4" />
 
         <config-file target="res/xml/config.xml" parent="/*">
             <feature name="LocalNotification">


### PR DESCRIPTION
The id of android v4 support library has changed from "android.support.v4" to "cordova-plugin-android-support-v4".