### PR TITLE
Have update event pass updated notification to callback

### DIFF
--- a/src/ios/APPLocalNotification.m
+++ b/src/ios/APPLocalNotification.m
@@ -110,7 +110,7 @@
             if (!notification)
                 continue;
 
-            [self updateLocalNotification:[notification copy]
+            notification = [self updateLocalNotification:notification
                               withOptions:options];
 
             [self fireEvent:@"update" notification:notification];
@@ -491,7 +491,7 @@
 /**
  * Update the local notification.
  */
-- (void) updateLocalNotification:(UILocalNotification*)notification
+- (UILocalNotification*) updateLocalNotification:(UILocalNotification*)notification
                      withOptions:(NSDictionary*)newOptions
 {
     NSMutableDictionary* options = [notification.userInfo mutableCopy];
@@ -503,6 +503,8 @@
                     initWithOptions:options];
 
     [self scheduleLocalNotification:notification];
+  
+    return notification ;
 }
 
 /**


### PR DESCRIPTION
Have update event pass the updated notification to its callback, not the original notification.  If user data is updated, the update event callback won't receive it.