### PR TITLE
Fix compatibility w/ other plugins due to android-support-v4.jar

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -79,7 +79,7 @@
     <!-- android -->
     <platform name="android">
 
-        <dependency id="cordova-plugin-android-support-v4" />
+        <framework src="com.android.support:support-v4:+" />
 
         <config-file target="res/xml/config.xml" parent="/*">
             <feature name="LocalNotification">


### PR DESCRIPTION
Changing android-support dependency declaration to be compatible with other plugins like phonegap-plugin-push and cordova-plugin-facebook4. Issue katzer/cordova-plugin-local-notifications#632