### PR TITLE
Use framework tag not dependency for Android support library

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -79,7 +79,7 @@
     <!-- android -->
     <platform name="android">
 
-        <dependency id="cordova-plugin-android-support-v4" />
+	<framework src="com.android.support:support-v4:+" />
 
         <config-file target="res/xml/config.xml" parent="/*">
             <feature name="LocalNotification">


### PR DESCRIPTION
Many Cordova/PhoneGap plugins have moved to using the framework tag to specify the inclusion of the Android Support Library jars. This effectively gets around the issue where two plugins are adding in different versions of the support framework jars. No more Dex errors!

For instance if you use this plugin with the https://github.com/phonegap/phonegap-plugin-push on Android your app will not compile because of Dex errors.