### PR TITLE
Fix getTriggerTime() on Android

### DIFF
--- a/src/android/notification/Notification.java
+++ b/src/android/notification/Notification.java
@@ -175,6 +175,10 @@ public class Notification {
                 context, 0, intent, PendingIntent.FLAG_CANCEL_CURRENT);
 
         if (isRepeating()) {
+            if (wasInThePast()) {
+                triggerTime = System.currentTimeMillis();
+            }
+
             getAlarmMgr().setRepeating(AlarmManager.RTC_WAKEUP,
                     triggerTime, options.getRepeatInterval(), pi);
         } else {

--- a/src/android/notification/Options.java
+++ b/src/android/notification/Options.java
@@ -213,10 +213,7 @@ public class Options {
      * Trigger date in milliseconds.
      */
     public long getTriggerTime() {
-        return Math.max(
-                System.currentTimeMillis(),
-                options.optLong("at", 0) * 1000
-        );
+        return options.optLong("at", 0) * 1000;
     }
 
     /**


### PR DESCRIPTION
- underlying issue is `wasInThePast()` always returning false.
  which in turn caused all past notifications to be restored on boot time and triggered immediately.

Fixes #700.