### PR TITLE
Catch previously-valid notification non-int keys.

### DIFF
--- a/src/android/notification/Manager.java
+++ b/src/android/notification/Manager.java
@@ -30,6 +30,7 @@ import android.content.SharedPreferences;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.lang.NumberFormatException;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.Iterator;
@@ -193,7 +194,11 @@ public class Manager {
         ArrayList<Integer> ids = new ArrayList<Integer>();
 
         for (String key : keys) {
-            ids.add(Integer.parseInt(key));
+            try {
+                ids.add(Integer.parseInt(key));
+            } catch (NumberFormatException e) {
+                e.printStackTrace();
+            }
         }
 
         return ids;


### PR DESCRIPTION
In previous old versions of the plugin, we were able to use non-integer values as notification keys (eg ms timestamp, which is a `long`). This isn't possible now, but a `NumberFormatException` exception is thrown when trying to add these to a list of `Integers`.