### PR TITLE
expect the every option to always be a string on iOS. display a warni…

### DIFF
--- a/www/local-notification-util.js
+++ b/www/local-notification-util.js
@@ -172,6 +172,16 @@ exports.convertProperties = function (options) {
         options.data = JSON.stringify(options.data);
     }
 
+    if (options.every)
+        if (device.platform == 'iOS' && typeof options.every != 'string') {
+            options.every = this.getDefaults().every;
+            var warning = 'Every option is not a string: ' + options.id;
+            warning += '. Expects one of: second, minute, hour, day, week, ';
+            warning += 'month, year on iOS.';
+            console.warn(warning);
+        }
+    }
+
     return options;
 };
 


### PR DESCRIPTION
…ng if it is not.

I noticed that my app would freeze when using a number for the "every" option on iOS. I threw together a quick patch to check that this value is a string on iOS and warn the developer (as well as preventing the error causing the freeze).