### PR TITLE
fixed reference error when calling un function

### DIFF
--- a/www/local-notification.js
+++ b/www/local-notification.js
@@ -372,5 +372,5 @@ exports.on = function (event, callback, scope) {
  *      The function to be exec as callback
  */
 exports.un = function (event, callback) {
-    this.core.un(event, callback, scope);
+    this.core.un(event, callback);
 };


### PR DESCRIPTION
removed unused ‘scope’ variable from un function.