### PR TITLE
Android: Prevent the notification builder from setting a null sound

### DIFF
--- a/src/android/notification/Builder.java
+++ b/src/android/notification/Builder.java
@@ -130,7 +130,7 @@ public class Builder {
                 .setColor(options.getColor())
                 .setLights(options.getLedColor(), 100, 100);
 
-        if (sound != null) {
+        if (!sound.equals(Uri.EMPTY)) {
             builder.setSound(sound);
         }
 


### PR DESCRIPTION
When the sound is set to null, the notification builder still set a null sound. 
This somehow triggers the vibrator when the android sound setting is "vibrate" as described in #837. 
