### PR TITLE
Prepend default icon with missing prefix

### DIFF
--- a/src/android/notification/Options.java
+++ b/src/android/notification/Options.java
@@ -132,7 +132,7 @@ public class Options {
         if (options.has("iconUri") && !options.optBoolean("updated"))
             return;
 
-        Uri iconUri  = assets.parse(options.optString("icon", "icon"));
+        Uri iconUri  = assets.parse(options.optString("icon", "res://icon"));
         Uri soundUri = assets.parseSound(options.optString("sound", null));
 
         try {


### PR DESCRIPTION
* assets.parse expects prefix of res://, file://, or http://.