### PR TITLE
Using application icon as default small icon

### DIFF
--- a/src/android/notification/Builder.java
+++ b/src/android/notification/Builder.java
@@ -135,7 +135,7 @@ public class Builder {
         }
 
         if (smallIcon == 0) {
-            builder.setSmallIcon(options.getIcon());
+            builder.setSmallIcon(context.getApplicationInfo().icon);
         } else {
             builder.setSmallIcon(options.getSmallIcon());
             builder.setLargeIcon(options.getIconBitmap());


### PR DESCRIPTION
Prevent bell icon reported in #890

Example:
![Imgur](http://i.imgur.com/b5EG22b.jpg)
