### PR TITLE
fix crash on samsung devices, 500 alarms limit, fix IOS 10 notifications

### DIFF
--- a/src/android/LocalNotification.java
+++ b/src/android/LocalNotification.java
@@ -37,6 +37,7 @@ import org.json.JSONObject;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
+import java.lang.Exception;
 
 import de.appplant.cordova.plugin.notification.Manager;
 import de.appplant.cordova.plugin.notification.Notification;
@@ -213,10 +214,18 @@ public class LocalNotification extends CordovaPlugin {
         for (int i = 0; i < notifications.length(); i++) {
             JSONObject options = notifications.optJSONObject(i);
 
-            Notification notification =
-                    getNotificationMgr().schedule(options, TriggerReceiver.class);
+            try {
+                Notification notification =
+                        getNotificationMgr().schedule(options, TriggerReceiver.class);
 
-            fireEvent("schedule", notification);
+                fireEvent("schedule", notification);
+            }
+            catch(Exception generic) {
+                //silently ignore the exception
+                //on some samsung devices there is a known bug where a 500 alarms limit can crash the app
+                //http://developer.samsung.com/forum/board/thread/view.do?boardName=General&messageId=280286&listLines=15&startId=zzzzz%7E&searchSubId=0000000001
+                
+            }
         }
     }
 

--- a/src/ios/APPLocalNotification.m
+++ b/src/ios/APPLocalNotification.m
@@ -78,6 +78,8 @@
 
             notification = [[UILocalNotification alloc]
                             initWithOptions:options];
+            notification.timeZone = [NSTimeZone defaultTimeZone];
+            notification.repeatInterval = 0;
 
             [self scheduleLocalNotification:[notification copy]];
             [self fireEvent:@"schedule" notification:notification];
@@ -710,6 +712,7 @@
          NSDateComponents *dateComponents = [gregorianCalendar components:NSYearCalendarUnit | NSMonthCalendarUnit | NSDayCalendarUnit
          | NSHourCalendarUnit | NSMinuteCalendarUnit | NSSecondCalendarUnit
                                                            fromDate:fireDate];
+         [dateComponents setTimeZone:[NSTimeZone defaultTimeZone]];
         
         /// 4. update application icon badge number
         //content.badge = @([[UIApplication sharedApplication] applicationIconBadgeNumber] + 1);

--- a/src/ios/APPLocalNotification.m
+++ b/src/ios/APPLocalNotification.m
@@ -699,26 +699,25 @@
         content.body = [NSString localizedUserNotificationStringForKey:notification.alertBody
                                                          arguments:nil];
         content.sound = [UNNotificationSound defaultSound];
-    
+
+        
         NSDate *fireDate = notification.fireDate;
-        
-        NSCalendar *gregorianCalendar = [[NSCalendar alloc] initWithCalendarIdentifier:NSGregorianCalendar];
-        
+        if(fireDate==nil) {
+            fireDate = [NSDate date];
+        }
+         NSCalendar *gregorianCalendar = [[NSCalendar alloc] initWithCalendarIdentifier:NSGregorianCalendar];
         // Extract all date components into dateComponents
-        NSDateComponents *dateComponents = [gregorianCalendar components:NSYearCalendarUnit | NSMonthCalendarUnit | NSDayCalendarUnit | NSHourCalendarUnit | NSMinuteCalendarUnit | NSSecondCalendarUnit
-                                                             fromDate:fireDate];
+         NSDateComponents *dateComponents = [gregorianCalendar components:NSYearCalendarUnit | NSMonthCalendarUnit | NSDayCalendarUnit
+         | NSHourCalendarUnit | NSMinuteCalendarUnit | NSSecondCalendarUnit
+                                                           fromDate:fireDate];
+        
         /// 4. update application icon badge number
-        content.badge = @([[UIApplication sharedApplication] applicationIconBadgeNumber] + 1);
+        //content.badge = @([[UIApplication sharedApplication] applicationIconBadgeNumber] + 1);
         
         // Deliver the notification at the fire date.
         UNCalendarNotificationTrigger *trigger = [UNCalendarNotificationTrigger triggerWithDateMatchingComponents:dateComponents repeats:NO];
         
-        NSString *identifier = @"DefaultNotificationIdentifier";
-        if(notification.userInfo!=nil && [notification.userInfo objectForKey:@"id"]!=nil) {
-            identifier = [notification.userInfo objectForKey:@"id"];
-        }
-        
-        UNNotificationRequest *request = [UNNotificationRequest requestWithIdentifier:identifier content:content trigger:trigger];
+        UNNotificationRequest *request = [UNNotificationRequest requestWithIdentifier:@"DefaultNotificationIdentifier" content:content trigger:trigger];
         
         /// 3. schedule localNotification
         UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];

--- a/src/ios/APPLocalNotification.m
+++ b/src/ios/APPLocalNotification.m
@@ -717,7 +717,12 @@
         // Deliver the notification at the fire date.
         UNCalendarNotificationTrigger *trigger = [UNCalendarNotificationTrigger triggerWithDateMatchingComponents:dateComponents repeats:NO];
         
-        UNNotificationRequest *request = [UNNotificationRequest requestWithIdentifier:@"DefaultNotificationIdentifier" content:content trigger:trigger];
+        NSString *identifier = @"DefaultNotificationIdentifier";
+        if(notification.userInfo!=nil && [notification.userInfo objectForKey:@"id"]!=nil) {
+            identifier = [notification.userInfo objectForKey:@"id"];
+        }
+        
+        UNNotificationRequest *request = [UNNotificationRequest requestWithIdentifier:identifier content:content trigger:trigger];
         
         /// 3. schedule localNotification
         UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];

--- a/src/ios/APPLocalNotification.m
+++ b/src/ios/APPLocalNotification.m
@@ -700,13 +700,26 @@
                                                          arguments:nil];
         content.sound = [UNNotificationSound defaultSound];
     
-        /// 4. update application icon badge numberß
-        //content.badge = @([[UIApplication sharedApplication] applicationIconBadgeNumber] + 1);
-        // Deliver the notification in five seconds.
-        UNTimeIntervalNotificationTrigger *trigger = [UNTimeIntervalNotificationTrigger
-                                                  triggerWithTimeInterval:1.f repeats:NO];
-        UNNotificationRequest *request = [UNNotificationRequest requestWithIdentifier:@"FiveSecond"
-                                                                          content:content trigger:trigger];
+        NSDate *fireDate = notification.fireDate;
+        
+        NSCalendar *gregorianCalendar = [[NSCalendar alloc] initWithCalendarIdentifier:NSGregorianCalendar];
+        
+        // Extract all date components into dateComponents
+        NSDateComponents *dateComponents = [gregorianCalendar components:NSYearCalendarUnit | NSMonthCalendarUnit | NSDayCalendarUnit | NSHourCalendarUnit | NSMinuteCalendarUnit | NSSecondCalendarUnit
+                                                             fromDate:fireDate];
+        /// 4. update application icon badge number
+        content.badge = @([[UIApplication sharedApplication] applicationIconBadgeNumber] + 1);
+        
+        // Deliver the notification at the fire date.
+        UNCalendarNotificationTrigger *trigger = [UNCalendarNotificationTrigger triggerWithDateMatchingComponents:dateComponents repeats:NO];
+        
+        NSString *identifier = @"DefaultNotificationIdentifier";
+        if(notification.userInfo!=nil && [notification.userInfo objectForKey:@"id"]!=nil) {
+            identifier = [notification.userInfo objectForKey:@"id"];
+        }
+        
+        UNNotificationRequest *request = [UNNotificationRequest requestWithIdentifier:identifier content:content trigger:trigger];
+        
         /// 3. schedule localNotification
         UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
         [center addNotificationRequest:request withCompletionHandler:^(NSError * _Nullable error) {

--- a/src/ios/APPLocalNotification.m
+++ b/src/ios/APPLocalNotification.m
@@ -26,6 +26,8 @@
 #import "UIApplication+APPLocalNotification.h"
 #import "UILocalNotification+APPLocalNotification.h"
 
+ @import UserNotifications;
+
 @interface APPLocalNotification ()
 
 // Retrieves the application state
@@ -691,26 +693,50 @@
  */
 - (void) fireEvent:(NSString*)event notification:(UILocalNotification*)notification
 {
-    NSString* js;
-    NSString* params = [NSString stringWithFormat:
-                        @"\"%@\"", self.applicationState];
-
-    if (notification) {
-        NSString* args = [notification encodeToJSON];
-
-        params = [NSString stringWithFormat:
-                  @"%@,'%@'",
-                  args, self.applicationState];
-    }
-
-    js = [NSString stringWithFormat:
-          @"cordova.plugins.notification.local.core.fireEvent('%@', %@)",
-          event, params];
-
-    if (deviceready) {
-        [self.commandDelegate evalJs:js];
+    if (IsAtLeastiOSVersion(@"10.0")) {
+        UNMutableNotificationContent *content = [[UNMutableNotificationContent alloc] init];
+        content.title = [NSString localizedUserNotificationStringForKey:notification.alertTitle arguments:nil];
+        content.body = [NSString localizedUserNotificationStringForKey:notification.alertBody
+                                                         arguments:nil];
+        content.sound = [UNNotificationSound defaultSound];
+    
+        /// 4. update application icon badge numberß
+        //content.badge = @([[UIApplication sharedApplication] applicationIconBadgeNumber] + 1);
+        // Deliver the notification in five seconds.
+        UNTimeIntervalNotificationTrigger *trigger = [UNTimeIntervalNotificationTrigger
+                                                  triggerWithTimeInterval:1.f repeats:NO];
+        UNNotificationRequest *request = [UNNotificationRequest requestWithIdentifier:@"FiveSecond"
+                                                                          content:content trigger:trigger];
+        /// 3. schedule localNotification
+        UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
+        [center addNotificationRequest:request withCompletionHandler:^(NSError * _Nullable error) {
+            if (!error) {
+                NSLog(@"add NotificationRequest succeeded!");
+            }
+        }];
     } else {
-        [self.eventQueue addObject:js];
+
+        NSString* js;
+        NSString* params = [NSString stringWithFormat:
+                            @"\"%@\"", self.applicationState];
+
+        if (notification) {
+            NSString* args = [notification encodeToJSON];
+
+            params = [NSString stringWithFormat:
+                      @"%@,'%@'",
+                      args, self.applicationState];
+        }
+
+        js = [NSString stringWithFormat:
+              @"cordova.plugins.notification.local.core.fireEvent('%@', %@)",
+              event, params];
+
+        if (deviceready) {
+            [self.commandDelegate evalJs:js];
+        } else {
+            [self.eventQueue addObject:js];
+        }
     }
 }
 

--- a/src/ios/UILocalNotification+APPLocalNotification.m
+++ b/src/ios/UILocalNotification+APPLocalNotification.m
@@ -61,6 +61,12 @@ NSInteger const APPLocalNotificationTypeTriggered = 2;
     self.fireDate = options.fireDate;
     self.timeZone = [NSTimeZone defaultTimeZone];
     self.applicationIconBadgeNumber = options.badgeNumber;
+    //TODO check this fix from: https://github.com/EddyVerbruggen/cordova-plugin-local-notifications.git
+    /**
+    if (NSCalendarUnitEra != options.repeatInterval) {
+        self.repeatInterval = options.repeatInterval;
+    }
+    */
     self.repeatInterval = options.repeatInterval;
     self.alertBody = options.alertBody;
     self.soundName = options.soundName;


### PR DESCRIPTION
On many samsung devices the app crashes while trying to add/schedule the notifications, due to the issue reported here:
http://developer.samsung.com/forum/board/thread/view.do?boardName=General&messageId=280286&listLines=15&startId=zzzzz%7E&searchSubId=0000000001
It seems that the fix done in the plugin does not entirely solves entirely the issue, as per some user reports
One way to avoid the nasty crash could be simply adding a try / catch on the `schedule` method
