### PR TITLE
check hex code for colors

### DIFF
--- a/src/android/notification/Options.java
+++ b/src/android/notification/Options.java
@@ -240,12 +240,20 @@ public class Options {
      */
     public int getLedColor() {
         String hex = options.optString("led", null);
-
+        if (hex.charAt(0) == "#") {
+            hex = hex.substring(1);
+        }
         if (hex == null) {
             return 0;
         }
-
-        int aRGB = Integer.parseInt(hex, 16);
+        
+        int aRGB = 0;
+        try {
+            aRGB = Integer.parseInt(hex, 16);
+        } catch (NumberFormatException e) {
+            e.printStackTrace();
+            return 0;
+        }
 
         return aRGB + 0xFF000000;
     }
@@ -262,7 +270,13 @@ public class Options {
             return NotificationCompat.COLOR_DEFAULT;
         }
 
-        int aRGB = Integer.parseInt(hex, 16);
+        int aRGB = 0;
+        try {
+            aRGB = Integer.parseInt(hex, 16);
+        } catch (NumberFormatException e) {
+            e.printStackTrace();
+            return 0;
+        }
 
         return aRGB + 0xFF000000;
     }

--- a/src/android/notification/Options.java
+++ b/src/android/notification/Options.java
@@ -240,11 +240,11 @@ public class Options {
      */
     public int getLedColor() {
         String hex = options.optString("led", null);
-        if (hex.charAt(0) == "#") {
-            hex = hex.substring(1);
-        }
         if (hex == null) {
             return 0;
+        }
+        if (hex.charAt(0) == "#") {
+            hex = hex.substring(1);
         }
         
         int aRGB = 0;
@@ -265,12 +265,12 @@ public class Options {
      */
     public int getColor() {
         String hex = options.optString("color", null);
-        if (hex.charAt(0) == "#") {
-            hex = hex.substring(1);
-        }
 
         if (hex == null) {
             return NotificationCompat.COLOR_DEFAULT;
+        }
+        if (hex.charAt(0) == "#") {
+            hex = hex.substring(1);
         }
 
         int aRGB = 0;

--- a/src/android/notification/Options.java
+++ b/src/android/notification/Options.java
@@ -265,6 +265,9 @@ public class Options {
      */
     public int getColor() {
         String hex = options.optString("color", null);
+        if (hex.charAt(0) == "#") {
+            hex = hex.substring(1);
+        }
 
         if (hex == null) {
             return NotificationCompat.COLOR_DEFAULT;


### PR DESCRIPTION
We broke our app by setting the led color options as "#FF00FF". (I know, I should've read the wiki more carefully). But to avoid such problems, I added a check for a hash  and also did the parseInt inside a try-catch block.
