### PR TITLE
Prevent Update From Refiring Notification

### DIFF
--- a/src/android/notification/Manager.java
+++ b/src/android/notification/Manager.java
@@ -93,8 +93,8 @@ public class Manager {
                 .setTriggerReceiver(receiver)
                 .build();
 
-		notification.clear();
-		
+        notification.cancel();
+
         notification.schedule();
 
         return notification;
@@ -115,23 +115,23 @@ public class Manager {
 
         if (notification == null)
             return null;
-        
+
         JSONObject options = mergeJSONObjects(
                 notification.getOptions().getDict(), updates);
 
         try {
             options.put("updated", true);
         } catch (JSONException ignore) {}
-		
-		Options notificationOptions = new Options(context);
-		notificationOptions.parse(options);
-		
-		Notification displayNotification = new Builder(notificationOptions)
+
+        Options notificationOptions = new Options(context);
+        notificationOptions.parse(options);
+
+        Notification displayNotification = new Builder(notificationOptions)
                 .setTriggerReceiver(receiver)
                 .build();
-		
+
         displayNotification.schedule();
-		
+
         return displayNotification;
     }
 

--- a/src/android/notification/Manager.java
+++ b/src/android/notification/Manager.java
@@ -93,6 +93,8 @@ public class Manager {
                 .setTriggerReceiver(receiver)
                 .build();
 
+		notification.clear();
+		
         notification.schedule();
 
         return notification;
@@ -120,8 +122,17 @@ public class Manager {
         try {
             options.put("updated", true);
         } catch (JSONException ignore) {}
-
-        return schedule(options, receiver);
+		
+		Options notificationOptions = new Options(context);
+		notificationOptions.parse(options);
+		
+		Notification displayNotification = new Builder(notificationOptions)
+                .setTriggerReceiver(receiver)
+                .build();
+		
+        displayNotification.schedule();
+		
+        return displayNotification;
     }
 
     /**

--- a/src/android/notification/Manager.java
+++ b/src/android/notification/Manager.java
@@ -99,7 +99,7 @@ public class Manager {
     }
 
     /**
-     * Clear local notification specified by ID.
+     * Update local notification specified by ID.
      *
      * @param id
      *      The notification ID
@@ -113,9 +113,7 @@ public class Manager {
 
         if (notification == null)
             return null;
-
-        notification.cancel();
-
+        
         JSONObject options = mergeJSONObjects(
                 notification.getOptions().getDict(), updates);
 


### PR DESCRIPTION
[Android] Currently when the update method is called, it will cancel the previous message first and schedule a new one to replace it. This change will allow the notification to be updated without replacing the notification. When a notification is scheduled with the same ID, this will still replace the existing notification as expected.
