### PR TITLE
Prevent Click From Clearing Ongoing Notifications

### DIFF
--- a/src/android/ClickActivity.java
+++ b/src/android/ClickActivity.java
@@ -44,7 +44,7 @@ public class ClickActivity extends de.appplant.cordova.plugin.notification.Click
     public void onClick(Notification notification) {
         LocalNotification.fireEvent("click", notification);
 
-		launchApp();
+        launchApp();
 
         if (notification.getOptions().isOngoing())
             return;

--- a/src/android/ClickActivity.java
+++ b/src/android/ClickActivity.java
@@ -44,7 +44,7 @@ public class ClickActivity extends de.appplant.cordova.plugin.notification.Click
     public void onClick(Notification notification) {
         LocalNotification.fireEvent("click", notification);
 
-        super.onClick(notification);
+		launchApp();
 
         if (notification.getOptions().isOngoing())
             return;


### PR DESCRIPTION
[Android] Updated the ClickActivity.onClick method to not call the super method which clears ongoing notifications. It instead calls 'launchApp()' as it does in the super, performing the same behaviour without clearing the notification.
