### PR TITLE
Problem for 4.4.2 and Notification not trigerring at exact time in android 6 solution

### DIFF
--- a/src/android/notification/Notification.java
+++ b/src/android/notification/Notification.java
@@ -162,9 +162,9 @@ public class Notification {
     /**
      * Schedule the local notification.
      */
-    public void schedule() {
+      public void schedule() {
         long triggerTime = options.getTriggerTime();
-
+        int notiId=options.getId();
         persist();
 
         // Intent gets called when the Notification gets fired
@@ -173,16 +173,22 @@ public class Notification {
                 .putExtra(Options.EXTRA, options.toString());
 
         PendingIntent pi = PendingIntent.getBroadcast(
-                context, 0, intent, PendingIntent.FLAG_CANCEL_CURRENT);
+                context, notiId, intent, PendingIntent.FLAG_CANCEL_CURRENT);
 
         if (isRepeating()) {
             getAlarmMgr().setRepeating(AlarmManager.RTC_WAKEUP,
                     triggerTime, options.getRepeatInterval(), pi);
         } else {
-            getAlarmMgr().set(AlarmManager.RTC_WAKEUP, triggerTime, pi);
+             if (android.os.Build.VERSION.SDK_INT >= 19) {
+            getAlarmMgr().setExact(AlarmManager.RTC_WAKEUP, triggerTime, pi);
+             }
+            else
+            {
+                getAlarmMgr().set(AlarmManager.RTC_WAKEUP, triggerTime, pi);
+            }
         }
-    }
 
+    }
     /**
      * Clear the local notification without canceling repeating alarms.
      */


### PR DESCRIPTION
Solution for notification not triggering at exact time in android 6 (Marshmallow) and other solution for notification not triggering on time on Android devices 4.X.X(Jelly bean) 
Change in the following file ->cordova-plugin-local-notifications/src/android/notification/Notification.java
Change in function Schedule()

```
          public void schedule() {
                      long triggerTime = options.getTriggerTime();
                      int notiId=options.getId();
                       persist(); 

    // Intent gets called when the Notification gets fired
    Intent intent = new Intent(context, receiver)
            .setAction(options.getIdStr())
            .putExtra(Options.EXTRA, options.toString());

    PendingIntent pi = PendingIntent.getBroadcast(
            context, notiId, intent, PendingIntent.FLAG_CANCEL_CURRENT);

    if (isRepeating()) {
        getAlarmMgr().setRepeating(AlarmManager.RTC_WAKEUP,
                triggerTime, options.getRepeatInterval(), pi);
    } else {
         if (android.os.Build.VERSION.SDK_INT >= 19) {
        getAlarmMgr().setExact(AlarmManager.RTC_WAKEUP, triggerTime, pi);
         }
        else
        {
            getAlarmMgr().set(AlarmManager.RTC_WAKEUP, triggerTime, pi);
        }
    }

}
```
