### PR TITLE
Support resource files from raw directory for Android

### DIFF
--- a/src/android/notification/AssetUtil.java
+++ b/src/android/notification/AssetUtil.java
@@ -117,9 +117,32 @@ class AssetUtil {
             return getUriFromAsset(path);
         } else if (path.startsWith("http")){
             return getUriFromRemote(path);
+        }  else if (path.startsWith("raw://")){
+            return getUriForRaw(path);
         }
 
         return Uri.EMPTY;
+    }
+
+	/**
+     *
+     * URI for raw resource
+     *
+     * @param Raw resource name
+     * @return
+     */
+    private Uri getUriForRaw(String path) {
+        String resourceName = path.replaceFirst("raw://", "");
+        String packageName = context.getPackageName();
+
+        // we are going for this format "android.resource://[package]/[res type]/[res name]"
+        Uri.Builder builder = new Uri.Builder();
+        builder.scheme("android.resource");
+        builder.authority(packageName);
+        builder.appendPath("raw");
+        builder.appendPath(resourceName);
+
+        return builder.build();
     }
 
     /**


### PR DESCRIPTION
Working on our project we have faced with problem related with missing sound notification. Current plugin implementation suggests only one option which is to copy sound file from "assets" into cache folder. It works good only for immediate notifications. If we schedule notification say for next day Android might clear cache folder by the time notification triggers and obviously we will not get sound effect. The solution I suggest is to add ability to place sound files in "raw" resource directory for Android. In such way we do not need to copy it anywhere and can use them directly.
