### PR TITLE
iOS 10 Fix - Switching to removeAllPendingNotificationRequests

### DIFF
--- a/src/ios/APPLocalNotification.m
+++ b/src/ios/APPLocalNotification.m
@@ -653,7 +653,7 @@
 - (void) clearAllNotifications
 {
     if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"10.0")) {
-        [self.center clearAllNotifications];
+        [self.center removeAllPendingNotificationRequests];
     } else {
         [self.app clearAllLocalNotifications];
     }


### PR DESCRIPTION
I was having problems until changing this now it works (iOS 10) From what I see this is the proper way to clear notifications.

https://developer.apple.com/reference/usernotifications/unusernotificationcenter/1649509-removeallpendingnotificationrequ?language=objc
