### PR TITLE
Android: Support long notifications with preview while minimized

### DIFF
--- a/src/android/notification/Builder.java
+++ b/src/android/notification/Builder.java
@@ -120,8 +120,12 @@ public class Builder {
         int ledColor  = options.getLedColor();
         NotificationCompat.Builder builder;
 
-        builder = new NotificationCompat.Builder(context)
-                .setDefaults(0)
+        builder = new NotificationCompat.Builder(context);
+        
+        builder.setStyle(new NotificationCompat.BigTextStyle()
+                    .bigText(options.getText())
+                    .setBigContentTitle(options.getTitle()))
+	            .setDefaults(0)
                 .setContentTitle(options.getTitle())
                 .setContentText(options.getText())
                 .setNumber(options.getBadgeNumber())


### PR DESCRIPTION
**BEFORE:** 
First notification is a small one with current plugin code (even with a long text)
![screenshot_20170307-155731](https://cloud.githubusercontent.com/assets/26327976/24002604/7a0cf2e6-0a61-11e7-8ec6-ac829368ed88.png)

**AFTER:**
First notification is a big one (if needed) with the pull request, the others are minimized
![screenshot_20170314-114306](https://cloud.githubusercontent.com/assets/26327976/24002718/c17dc970-0a61-11e7-8c96-c883859f5513.png)

But resizable by fingers to extend them if needed
![screenshot_20170314-114315](https://cloud.githubusercontent.com/assets/26327976/24002780/ec4c6936-0a61-11e7-86f9-6d1fec3524b6.png)



The pull request concern only android => "builder.java" to add support of bigtext (tested on Android 6.0.0)
Need to keep the setContentTitle / setContentText because "BigText" act only if extended (remove this lines will change your minimized notifications as "blank" one)