### PR TITLE
Get resource id for drawable also from mipmap resources

### DIFF
--- a/src/android/notification/AssetUtil.java
+++ b/src/android/notification/AssetUtil.java
@@ -329,6 +329,14 @@ class AssetUtil {
             resId = (Integer) cls.getDeclaredField(drawable).get(Integer.class);
         } catch (Exception ignore) {}
 
+        if(resId == 0) {
+            try {
+                Class<?> cls  = Class.forName(clsName + ".R$mipmap");
+
+                resId = (Integer) cls.getDeclaredField(drawable).get(Integer.class);
+            } catch (Exception ignore) {}
+        }
+
         return resId;
     }
 


### PR DESCRIPTION
I wanted to use app icon for smallIcon, but it wasn't working because in recent versions of android the app icon is put in the res/mipmap folders. This should fix the issue