### PR TITLE
Use mipmap icons if drawables not found

### DIFF
--- a/src/android/notification/AssetUtil.java
+++ b/src/android/notification/AssetUtil.java
@@ -322,12 +322,20 @@ class AssetUtil {
     int getResIdForDrawable(String clsName, String resPath) {
         String drawable = getBaseName(resPath);
         int resId = 0;
+        Class<?> cls;
 
         try {
-            Class<?> cls  = Class.forName(clsName + ".R$drawable");
+            cls  = Class.forName(clsName + ".R$drawable");
 
             resId = (Integer) cls.getDeclaredField(drawable).get(Integer.class);
-        } catch (Exception ignore) {}
+        } catch (Exception ignore) {
+            // Drawable not found, search in mipmap now.
+            try {
+                cls  = Class.forName(clsName + ".R$mipmap");
+
+                resId = (Integer) cls.getDeclaredField(drawable).get(Integer.class);
+            } catch (Exception ignore2) {}
+        }
 
         return resId;
     }


### PR DESCRIPTION
In latest Cordova versions, the app icon is copied to res/mipmap instead of res/drawable. This means that the plugin will not find the icons if they are set using the "res://" format. This Pull Request intends to fix this, searching in the mipmap resources if the drawable isn't found.