### PR TITLE
Fix intervals for repeatable notifications on ios10

### DIFF
--- a/src/ios/APPLocalNotificationOptions.m
+++ b/src/ios/APPLocalNotificationOptions.m
@@ -226,28 +226,28 @@
 
 
     if ([self stringIsNullOrEmpty:interval]) {
-        return unitFlags;
-    }
-    else if ([interval isEqualToString:@"second"]) {
-        return NSCalendarUnitYear|NSCalendarUnitMonth|NSCalendarUnitDay;
-    }
+            return unitFlags;
+        }
+//    else if ([interval isEqualToString:@"second"]) { // TODO
+//        return NSCalendarUnitSecond;
+//    }
     else if ([interval isEqualToString:@"minute"]) {
-        return NSCalendarUnitYear|NSCalendarUnitMonth|NSCalendarUnitDay|NSCalendarUnitSecond;
+        return NSCalendarUnitSecond;
     }
     else if ([interval isEqualToString:@"hour"]) {
-        return NSCalendarUnitYear|NSCalendarUnitMonth|NSCalendarUnitDay|NSCalendarUnitMinute;
+        return  NSCalendarUnitMinute | NSCalendarUnitSecond;
     }
     else if ([interval isEqualToString:@"day"]) {
-        return NSCalendarUnitHour|NSCalendarUnitMinute;
+        return NSCalendarUnitHour | NSCalendarUnitMinute | NSCalendarUnitSecond;
     }
     else if ([interval isEqualToString:@"week"]) {
-        return NSCalendarUnitWeekday|NSCalendarUnitHour|NSCalendarUnitMinute;
+        return NSCalendarUnitWeekday | NSCalendarUnitHour | NSCalendarUnitMinute | NSCalendarUnitSecond;
     }
     else if ([interval isEqualToString:@"month"]) {
-        return NSCalendarUnitDay|NSCalendarUnitHour|NSCalendarUnitMinute;
+        return NSCalendarUnitDay | NSCalendarUnitHour | NSCalendarUnitMinute | NSCalendarUnitSecond;
     }
     else if ([interval isEqualToString:@"year"]) {
-        return NSCalendarUnitMonth|NSCalendarUnitDay|NSCalendarUnitHour|NSCalendarUnitMinute;
+        return NSCalendarUnitMonth | NSCalendarUnitDay | NSCalendarUnitHour | NSCalendarUnitMinute | NSCalendarUnitSecond;
     }
 
     return unitFlags;


### PR DESCRIPTION
Fix intervals for repeatable notifications.

Based on https://stackoverflow.com/a/40852161/506954 

Not sure what should be under seconds, but I am not even sure that the `every seconds` option should be available for notifications.

Right now notifications behaves as expected first and all next runs, while the before's solution worked unexpectedly.