### PR TITLE
Android: Support set priority notifications 

### DIFF
--- a/src/android/notification/Builder.java
+++ b/src/android/notification/Builder.java
@@ -130,7 +130,8 @@ public class Builder {
                 .setAutoCancel(options.isAutoClear())
                 .setOngoing(options.isOngoing())
                 .setColor(options.getColor());
-
+                .setPriority(options.getPriority());
+        
         if (ledColor != 0) {
             builder.setLights(ledColor, options.getLedOnTime(), options.getLedOffTime());
         }

--- a/src/android/notification/Options.java
+++ b/src/android/notification/Options.java
@@ -200,6 +200,12 @@ public class Options {
         return options.optInt("id", 0);
     }
 
+     /**
+     * Priority for the local notification as a number.
+     */
+    public int getPriority () {
+       return options.optInt("priority", 0);
+    }
     /**
      * ID for the local notification as a string.
      */

--- a/www/local-notification-util.js
+++ b/www/local-notification-util.js
@@ -36,6 +36,7 @@ exports._defaults = {
     sound: 'res://platform_default',
     badge: 0,
     id:    0,
+    priority: 0,
     data:  undefined,
     every: undefined,
     at:    undefined
@@ -160,6 +161,15 @@ exports.convertProperties = function (options) {
             console.warn('Badge number is not a number: ' + options.id);
         } else {
             options.badge = Number(options.badge);
+        }
+    }
+    
+    if (options.priority) {
+        if (isNaN(options.priority)) {
+            options.priority = this.getDefaults().priority;
+            console.warn('Priority number is not a number: ' + options.id);
+        } else {
+            options.priority = Number(options.priority);
         }
     }
 


### PR DESCRIPTION
Modified in the android module, referring to the priority of local notifications.

Use: 
  cordova.plugins.notification.local.schedule({
        title: "example",
        message: "example priority",
        priority: 2
    });