### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /gen
 /platforms/android/CordovaLib/build
 /platforms/windows/build
+/node_modules


### PR DESCRIPTION
removing node_modules from repo.
users can just run `$ npm install`