### PR TITLE
Save delegate and proxy calls to previous delegate

### DIFF
--- a/src/ios/APPLocalNotification.m
+++ b/src/ios/APPLocalNotification.m
@@ -28,6 +28,7 @@
 @interface APPLocalNotification ()
 
 @property (strong, nonatomic) UNUserNotificationCenter* center;
+@property (NS_NONATOMIC_IOSONLY, nullable, weak) id <UNUserNotificationCenterDelegate> delegate;
 @property (readwrite, assign) BOOL deviceready;
 @property (readwrite, assign) BOOL isActive;
 @property (readonly, nonatomic, retain) NSArray* launchDetails;
@@ -131,7 +132,7 @@
 
             [self fireEvent:@"update" notification:notification];
         }
-        
+
         [self check:command];
     }];
 }
@@ -506,9 +507,11 @@
 {
     UNNotificationRequest* toast = notification.request;
 
-    if ([toast.trigger isKindOfClass:UNPushNotificationTrigger.class])
+    if ([toast.trigger isKindOfClass:UNPushNotificationTrigger.class]) {
+        [_delegate userNotificationCenter:center willPresentNotification:notification withCompletionHandler:completionHandler];
         return;
-    
+    }
+
     APPNotificationOptions* options = toast.options;
 
     if (![notification.request wasUpdated]) {
@@ -535,9 +538,11 @@
     UNNotificationRequest* toast = response.notification.request;
 
     completionHandler();
-    
-    if ([toast.trigger isKindOfClass:UNPushNotificationTrigger.class])
+
+    if ([toast.trigger isKindOfClass:UNPushNotificationTrigger.class]) {
+        [_delegate userNotificationCenter:center didReceiveNotificationResponse:response withCompletionHandler:completionHandler];
         return;
+    }
 
     NSMutableDictionary* data = [[NSMutableDictionary alloc] init];
     NSString* action          = response.actionIdentifier;
@@ -577,6 +582,7 @@
     eventQueue = [[NSMutableArray alloc] init];
     _center    = [UNUserNotificationCenter currentNotificationCenter];
 
+    _delegate = _center.delegate;
     _center.delegate = self;
     [_center registerGeneralNotificationCategory];
 


### PR DESCRIPTION
This solution will solve two plugins from disabling the other as a notification delegate in iOS. The current delegate set on the notification center is saved in a property. When presenting or handing response the handler checks the notification type as already present in the current code. If the notification type is a remote notification it is proxied to the previously available delegate.

This solves a current problem with the cordova-plugin-firebase:
1. Firebase registers as delegate
2. Local notifications registers as delegate
3. Remote push is received, is handled by local notifications and then returned without action.

And adds:
4. Local notifications calls Firebase's delegate and Firebase handles the remote notification as if it was the current delegate set on the notification center.

In my opinion this is something all plugins working with the notification center should do as there can only be one delegate set on the notification center, receiving all notifications remote or local.