### PR TITLE
[fix] broken browser platform when importing cordova-plugin-badge

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -50,7 +50,7 @@
 
     <!-- dependencies -->
     <dependency id="cordova-plugin-device" />
-    <dependency id="cordova-plugin-badge" version=">=0.8.5" />
+    <dependency id="cordova-plugin-badge" url="https://github.com/SymetriaSpJ/cordova-plugin-badge.git#7de8466" version=">=0.8.5" />
 
     <!-- js -->
     <js-module src="www/local-notification.js" name="LocalNotification">

--- a/plugin.xml
+++ b/plugin.xml
@@ -50,7 +50,7 @@
 
     <!-- dependencies -->
     <dependency id="cordova-plugin-device" />
-    <dependency id="cordova-plugin-badge" url="https://github.com/SymetriaSpJ/cordova-plugin-badge.git#7de8466" version=">=0.8.5" />
+    <dependency id="cordova-plugin-badge" url="https://github.com/SymetriaSpJ/cordova-plugin-badge.git#0b4032a" version=">=0.8.5" />
 
     <!-- js -->
     <js-module src="www/local-notification.js" name="LocalNotification">


### PR DESCRIPTION
Browser się wywalał w przypadku użycia cordova-plugin-local-notifications.
Plugin do notyfikacji zaciąga plugin badge a tu export libki gryzie się z naszym require.js.
Fix polega na tym, że wywaliłem eksportowanie libki favico do modułu requireowego