### PR TITLE
Encode Javascript code executed as URL

### DIFF
--- a/src/android/LocalNotification.java
+++ b/src/android/LocalNotification.java
@@ -571,7 +571,7 @@ public class LocalNotification extends CordovaPlugin {
      * @param js JS code snippet as string.
      */
     private static synchronized void sendJavascript(final String js) {
-
+        
         if (!deviceready || webView == null) {
             eventQueue.add(js);
             return;
@@ -579,9 +579,18 @@ public class LocalNotification extends CordovaPlugin {
 
         final CordovaWebView view = webView.get();
 
+        final String jsEncoded;
+
+        try {
+            jsEncoded = URLEncoder.encode(js, "UTF8");
+        } catch (UnsupportedEncodingException e) {
+            e.printStackTrace();
+            return;
+        }
+
         ((Activity)(view.getContext())).runOnUiThread(new Runnable() {
             public void run() {
-                view.loadUrl("javascript:" + js);
+                view.loadUrl("javascript:" + jsEncoded);
             }
         });
     }


### PR DESCRIPTION
I have a problem when using strings with special characters (e. g. '%') as notification data. The reason is it later converts to JSON and this JSON is used as part of Javascript which executed as URL in a browser. It would be safe to URL-encode all Javascript before sending it to execution.