### PR TITLE
Added ability to customize alarm volume in Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,10 +95,10 @@ cordova.plugins.notification.local.schedule([
 
 A notification does have a set of configurable properties. Not all of them are supported across all platforms.
 
-| Property      | Property      | Property      | Property      | Property      | Property      | Property      | Property      |
-| :------------ | :------------ | :------------ | :------------ | :------------ | :------------ | :------------ | :------------ |
-| id            | data          | timeoutAfter  | summary       | led           | clock         | channel       | actions       |
-| text          | icon          | attachments   | smallIcon     | color         | defaults      | launch        | groupSummary  |
+| Property      | Property      | Property      | Property      | Property      | Property      | Property      | Property      | Property      |
+| :------------ | :------------ | :------------ | :------------ | :------------ | :------------ | :------------ | :------------ | :------------ |
+| id            | data          | timeoutAfter  | summary       | led           | clock         | channel       | actions       | alarmVolume   |
+| text          | icon          | attachments   | smallIcon     | color         | defaults      | launch        | groupSummary  | resetDelay   |
 | title         | silent        | progressBar   | sticky        | vibrate       | priority      | mediaSession  | foreground    |
 | sound         | trigger       | group         | autoClear     | lockscreen    | number        | badge         | wakeup        |
 
@@ -409,6 +409,23 @@ If requesting via plug-in, a system dialog does pop up for the first time. Later
 cordova.plugins.notification.local.requestPermission(function (granted) { ... });
 ```
 
+On Android 8, special permissions are required to exit "do not disturb mode" (in case alarmVolume is defined).
+You can check these by using:
+
+```js
+cordova.plugins.notification.local.hasDoNotDisturbPermissions(function (granted) { ... })
+```
+
+... and you can request them by using:
+
+```js
+cordova.plugins.notification.local.requestDoNotDisturbPermissions(function (granted) { ... })
+```
+
+The only downside to not having these permissions granted is that alarmVolume and vibrate may not be
+honored on Android 8+ devices if the device is currently on silent when the notification fires (silent, not vibrate).
+In this situation, the notification will fire silently but still appear in the notification bar.
+
 <p align="center">
     <img src="images/ios-permission.png">
 </p>
@@ -495,10 +512,10 @@ See the sample app for how to use them.
 
 | Method   | Method            | Method          | Method         | Method        | Method           |
 | :------- | :---------------- | :-------------- | :------------- | :------------ | :--------------- |
-| schedule | cancelAll         | isTriggered     | get            | removeActions | un               |
-| update   | hasPermission     | getType         | getAll         | hasActions    | fireQueuedEvents |
-| clear    | requestPermission | getIds          | getScheduled   | getDefaults   |
-| clearAll | isPresent         | getScheduledIds | getTriggered   | setDefaults   |
+| schedule | cancelAll         | isTriggered     | get            | removeActions | un                              |
+| update   | hasPermission     | getType         | getAll         | hasActions    | fireQueuedEvents                |
+| clear    | requestPermission | getIds          | getScheduled   | getDefaults   | requestDoNotDisturbPermissions  |
+| clearAll | isPresent         | getScheduledIds | getTriggered   | setDefaults   | hasDoNotDisturbPermissions      |
 | cancel   | isScheduled       | getTriggeredIds | addActions     | on            |
 
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -134,6 +134,7 @@
         </config-file>
 
         <config-file target="AndroidManifest.xml" parent="/manifest">
+            <uses-permission android:name="android.permission.ACCESS_NOTIFICATION_POLICY" />
             <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
             <uses-permission android:name="android.permission.WAKE_LOCK" />
         </config-file>

--- a/src/android/notification/Builder.java
+++ b/src/android/notification/Builder.java
@@ -143,7 +143,7 @@ public final class Builder {
                 .setTimeoutAfter(options.getTimeout())
                 .setLights(options.getLedColor(), options.getLedOn(), options.getLedOff());
 
-        if (sound != Uri.EMPTY && !isUpdate()) {
+        if (!sound.equals(Uri.EMPTY) && !isUpdate()) {
             builder.setSound(sound);
         }
 

--- a/src/android/notification/Builder.java
+++ b/src/android/notification/Builder.java
@@ -147,6 +147,12 @@ public final class Builder {
             builder.setSound(sound);
         }
 
+        // API < 26.  Setting sound to null will prevent playing if we have no sound for any reason,
+        // including a 0 volume.
+        if (options.isWithoutSound()) {
+            builder.setSound(null);
+        }
+
         if (options.isWithProgressBar()) {
             builder.setProgress(
                     options.getProgressMaxValue(),

--- a/src/android/notification/Manager.java
+++ b/src/android/notification/Manager.java
@@ -23,11 +23,12 @@
 
 package de.appplant.cordova.plugin.notification;
 
-import android.annotation.SuppressLint;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.media.AudioAttributes;
+import android.net.Uri;
 import android.service.notification.StatusBarNotification;
 import android.support.v4.app.NotificationManagerCompat;
 
@@ -44,6 +45,8 @@ import static android.os.Build.VERSION.SDK_INT;
 import static android.os.Build.VERSION_CODES.M;
 import static android.os.Build.VERSION_CODES.O;
 import static android.support.v4.app.NotificationManagerCompat.IMPORTANCE_DEFAULT;
+import static android.support.v4.app.NotificationManagerCompat.IMPORTANCE_HIGH;
+import static android.support.v4.app.NotificationManagerCompat.IMPORTANCE_LOW;
 import static de.appplant.cordova.plugin.notification.Notification.PREF_KEY_ID;
 import static de.appplant.cordova.plugin.notification.Notification.Type.TRIGGERED;
 
@@ -53,13 +56,6 @@ import static de.appplant.cordova.plugin.notification.Notification.Type.TRIGGERE
  * cancel or clear local notifications.
  */
 public final class Manager {
-
-    // TODO: temporary
-    static final String CHANNEL_ID = "default-channel-id";
-
-    // TODO: temporary
-    private static final CharSequence CHANNEL_NAME = "Default channel";
-
     // The application context
     private Context context;
 
@@ -70,7 +66,6 @@ public final class Manager {
      */
     private Manager(Context context) {
         this.context = context;
-        createDefaultChannel();
     }
 
     /**
@@ -105,22 +100,74 @@ public final class Manager {
     }
 
     /**
-     * TODO: temporary
+     * Build channel with options
+     * @param soundUri Uri for custom sound (empty to use default)
+     * @param shouldVibrate whether not vibration should occur during the notification
+     * @param hasSound whether or not sound should play during the notification
+     * @param channelName the name of the channel (null will pick an appropriate default name
+     *                    for the options provided).
+     * @return channel ID of newly created (or reused) channel
      */
-    @SuppressLint("WrongConstant")
-    private void createDefaultChannel() {
+    public String buildChannelWithOptions(Uri soundUri, boolean shouldVibrate,
+                                        boolean hasSound, CharSequence channelName) {
+        String channelId;
+        CharSequence defaultChannelName;
+        int importance;
+
+        if (hasSound && shouldVibrate) {
+            channelId = Options.CHANNEL_ID_SOUND_VIBRATE;
+            defaultChannelName = Options.CHANNEL_NAME_SOUND_VIBRATE;
+            importance = IMPORTANCE_HIGH;
+            shouldVibrate = true;
+        } else if (hasSound) {
+            channelId = Options.CHANNEL_ID_SOUND;
+            defaultChannelName = Options.CHANNEL_NAME_SOUND;
+            importance = IMPORTANCE_DEFAULT;
+            shouldVibrate = false;
+        } else if (shouldVibrate) {
+            channelId = Options.CHANNEL_ID_VIBRATE;
+            defaultChannelName = Options.CHANNEL_NAME_VIBRATE;
+            importance = IMPORTANCE_LOW;
+            shouldVibrate = true;
+        } else {
+            channelId = Options.CHANNEL_ID_SILENT;
+            defaultChannelName = Options.CHANNEL_NAME_SILENT;
+            importance = IMPORTANCE_LOW;
+            shouldVibrate = false;
+        }
+
+        createChannel(channelId, channelName != null ? channelName : defaultChannelName,
+            importance, shouldVibrate, soundUri);
+
+        return channelId;
+    }
+
+    /**
+     * Create a channel
+     */
+    public void createChannel(String channelId, CharSequence channelName, int importance,
+                               Boolean shouldVibrate, Uri soundUri) {
         NotificationManager mgr = getNotMgr();
 
         if (SDK_INT < O)
             return;
 
-        NotificationChannel channel = mgr.getNotificationChannel(CHANNEL_ID);
+        NotificationChannel channel = mgr.getNotificationChannel(channelId);
 
         if (channel != null)
             return;
 
         channel = new NotificationChannel(
-                CHANNEL_ID, CHANNEL_NAME, IMPORTANCE_DEFAULT);
+            channelId, channelName, importance);
+
+        channel.enableVibration(shouldVibrate);
+
+        if (!soundUri.equals(Uri.EMPTY)) {
+            AudioAttributes attributes = new AudioAttributes.Builder()
+                .setUsage(AudioAttributes.USAGE_NOTIFICATION)
+                .build();
+            channel.setSound(soundUri, attributes);
+        }
 
         mgr.createNotificationChannel(channel);
     }

--- a/src/android/notification/Options.java
+++ b/src/android/notification/Options.java
@@ -87,6 +87,10 @@ public final class Options {
     // Default icon path
     private static final String DEFAULT_ICON = "res://icon";
 
+    public final static Integer DEFAULT_RESET_DELAY = 5;
+
+    public final static Integer VOLUME_NOT_SET = -1;
+
     // The original JSON object
     private final JSONObject options;
 
@@ -429,6 +433,21 @@ public final class Options {
     }
 
     /**
+     * Get the volume
+     */
+    public Integer getVolume() {
+        return options.optInt("alarmVolume", VOLUME_NOT_SET);
+    }
+
+    /**
+     * Returns the resetDelay until the sound changes revert back to the users settings.
+     * @return resetDelay
+     */
+    public Integer getResetDelay() {
+        return options.optInt("resetDelay", DEFAULT_RESET_DELAY);
+    }
+
+    /**
      * If the phone should vibrate.
      */
     public boolean isWithVibration() {
@@ -440,7 +459,8 @@ public final class Options {
      */
     public boolean isWithoutSound() {
         Object value = options.opt("sound");
-        return value == null || value.equals(false);
+        return value == null || value.equals(false)
+            || options.optInt("alarmVolume") == 0;
     }
 
     /**

--- a/src/windows/LocalNotificationProxy.js
+++ b/src/windows/LocalNotificationProxy.js
@@ -84,6 +84,33 @@ exports.request = function (success, error) {
 };
 
 /**
+ * Check to see if the user has allowed "Do Not Disturb" permissions for this app.
+ * This is required to use alarmVolume to take a user out of silent mode.
+ * 
+ * Callback contains true or false for whether or not we have this permission.
+ * 
+ * @param {Function} callback The function to be exec as the callback.
+ * @param {Object} scope callback function's scope 
+ */
+exports.hasDoNotDisturbPermission = function (success, error) {
+    impl.hasDoNotDisturbPermission(success, error);
+}
+
+/**
+ * Request "Do Not Disturb" permissions for this app.
+ * The only way to do this is to launch the global do not distrub settings for all apps.
+ * This permission is required to use alarmVolume to take a user out of silent mode.
+ * 
+ * Callback is deferred until 
+ * 
+ * @param {Function} callback The function to be exec as the callback.
+ * @param {Object} scope callback function's scope 
+ */
+exports.requestDoNotDisturbPermissions = function (success, error) {
+    impl.requestDoNotDisturbPermissions(success, error);
+}
+
+/**
  * Schedule notifications.
  *
  * @param [ Function ] success Success callback

--- a/www/local-notification.js
+++ b/www/local-notification.js
@@ -25,6 +25,7 @@ var exec    = require('cordova/exec'),
 // Defaults
 exports._defaults = {
     actions       : [],
+    alarmVolume   : -1,
     attachments   : [],
     autoClear     : true,
     badge         : null,
@@ -45,6 +46,7 @@ exports._defaults = {
     number        : 0,
     priority      : 0,
     progressBar   : false,
+    resetDelay   : 5,
     silent        : false,
     smallIcon     : 'res://icon',
     sound         : true,
@@ -84,6 +86,29 @@ exports.hasPermission = function (callback, scope) {
 exports.requestPermission = function (callback, scope) {
     this._exec('request', null, callback, scope);
 };
+
+/**
+ * Check to see if the user has allowed "Do Not Disturb" permissions for this app.
+ * This is required to use alarmVolume to take a user out of silent mode.
+ * 
+ * @param {Function} callback The function to be exec as the callback.
+ * @param {Object} scope callback function's scope 
+ */
+exports.hasDoNotDisturbPermissions = function (callback, scope) {
+    this._exec('hasDoNotDisturbPermissions', null, callback, scope);
+}
+
+/**
+ * Request "Do Not Disturb" permissions for this app.
+ * The only way to do this is to launch the global do not distrub settings for all apps.
+ * This permission is required to use alarmVolume to take a user out of silent mode.
+ * 
+ * @param {Function} callback The function to be exec as the callback.
+ * @param {Object} scope callback function's scope.
+ */
+exports.requestDoNotDisturbPermissions = function (callback, scope) {
+    this._exec('requestDoNotDisturbPermissions', null, callback, scope);
+}
 
 /**
  * Schedule notifications.


### PR DESCRIPTION
_NOTE:  This request is dependent on 02832e9, which is in pull request #1696_

- Added alarmVolume and resetDelay parameters.
These let the caller specify the volume how long to stay at that
volume before resetting.

- Added requestDoNotDisturbPermissions and hasDoNotDisturbPermissions
These allow the caller to check and request permissions to
take the user out of silent (for an alarm volume config).  This
also enables vibration when the phone is on silent (otherwise
vibration and volume do not work on Android 8+).