### PR TITLE
Make android support v4 framework version configurable

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -40,9 +40,9 @@
 
     <!-- cordova -->
     <engines>
-        <engine name="cordova"         version=">=3.6.0"  />
+        <engine name="cordova"         version=">=7.1.0"  />
         <engine name="cordova-plugman" version=">=4.3.0"  />
-        <engine name="cordova-android" version=">=6.0.0"  />
+        <engine name="cordova-android" version=">=6.3.0"  />
         <engine name="cordova-windows" version=">=4.2.0"  />
         <engine name="android-sdk"     version=">=26" />
         <engine name="apple-ios"       version=">=10.0.0" />
@@ -90,7 +90,8 @@
 
     <!-- android -->
     <platform name="android">
-        <framework src="com.android.support:support-v4:26.+" />
+        <preference name="ANDROID_SUPPORT_V4_VERSION" default="26.+" />
+        <framework src="com.android.support:support-v4:$ANDROID_SUPPORT_V4_VERSION" />
         <framework src="src/android/build/localnotification.gradle" custom="true" type="gradleReference"/>
 
         <config-file target="res/xml/config.xml" parent="/*">


### PR DESCRIPTION
Allow configuring the support-v4 framework version via the parameter, `ANDROID_SUPPORT_V4_VERSION`, to make this plugin compatible with other plugins that also require `com.android.support:support-v4`. See [this phonegap blog post](https://blog.phonegap.com/the-play-services-problem-with-cordova-applications-489c9aeb2e89) for a better explanation of why this is needed than I could write here.

Breaking engine requirements changes:
```
cordova >= 7.1.0 (from 3.6.0)
cordova-android >= 6.3.0. (from 6.0.0)
```