### PR TITLE
Fixed JS _exec() wrapper not properly sending argument value 0

### DIFF
--- a/www/local-notification.js
+++ b/www/local-notification.js
@@ -898,7 +898,7 @@ exports._exec = function (action, args, callback, scope) {
 
     if (Array.isArray(args)) {
         params = args;
-    } else if (args) {
+    } else if (args !== null) {
         params.push(args);
     }
 


### PR DESCRIPTION
iOS getAll() terminates due to uncaught exception as reported in katzer#1657, fixed by correcting the _exec() function not to skip just falsy values.