### PR TITLE
Add namespace to provider authority to prevent crashes on Android.

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -103,7 +103,7 @@
         <config-file target="AndroidManifest.xml" parent="/manifest/application">
             <provider
                 android:name="de.appplant.cordova.plugin.notification.util.AssetProvider"
-                android:authorities="${applicationId}.provider"
+                android:authorities="${applicationId}.localnotifications.provider"
                 android:exported="false"
                 android:grantUriPermissions="true" >
                 <meta-data

--- a/plugin.xml
+++ b/plugin.xml
@@ -44,7 +44,7 @@
         <engine name="cordova-plugman" version=">=4.3.0"  />
         <engine name="cordova-android" version=">=6.3.0"  />
         <engine name="cordova-windows" version=">=4.2.0"  />
-        <engine name="android-sdk"     version=">=26" />
+        <!-- <engine name="android-sdk"     version=">=26" /> -->
         <engine name="apple-ios"       version=">=10.0.0" />
     </engines>
 

--- a/src/android/notification/Options.java
+++ b/src/android/notification/Options.java
@@ -385,10 +385,6 @@ public final class Options {
         }
 
         if (resId == 0) {
-            resId = context.getApplicationInfo().icon;
-        }
-
-        if (resId == 0) {
             resId = android.R.drawable.ic_popup_reminder;
         }
 

--- a/src/android/notification/util/AssetUtil.java
+++ b/src/android/notification/util/AssetUtil.java
@@ -248,10 +248,6 @@ public final class AssetUtil {
     public int getResId(String resPath) {
         int resId = getResId(context.getResources(), resPath);
 
-        if (resId == 0) {
-            resId = getResId(Resources.getSystem(), resPath);
-        }
-
         return resId;
     }
 

--- a/src/android/notification/util/AssetUtil.java
+++ b/src/android/notification/util/AssetUtil.java
@@ -357,7 +357,7 @@ public final class AssetUtil {
      */
     private Uri getUriFromFile(File file) {
         try {
-            String authority = context.getPackageName() + ".provider";
+            String authority = context.getPackageName() + "localnotifications.provider";
             return AssetProvider.getUriForFile(context, authority, file);
         } catch (IllegalArgumentException e) {
             e.printStackTrace();


### PR DESCRIPTION
See https://github.com/katzer/cordova-plugin-local-notifications/issues/1664