### PR TITLE
Support circular icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@
 
 ## Important Notice
 
-Please make sure that you always read the tagged README for the version you're using. 
+Please make sure that you always read the tagged README for the version you're using.
 
 See the _0.8_ branch if you cannot upgrade. Further development for `v0.9-beta` will happen here. The `0.9-dev` and `ios10` branches are obsolate and will be removed soon.
 
@@ -100,6 +100,7 @@ A notification does have a set of configurable properties. Not all of them are s
 | text          | icon          | attachments   | smallIcon     | color         | defaults      | launch        | groupSummary  |
 | title         | silent        | progressBar   | sticky        | vibrate       | priority      | mediaSession  | foreground    |
 | sound         | trigger       | group         | autoClear     | lockscreen    | number        | badge         | wakeup        |
+| iconType
 
 For their default values see:
 
@@ -169,7 +170,7 @@ cordova.plugins.notification.local.addActions('yes-no', [
 ]);
 ```
 
-Once you have defined an action group, you can reference it when scheduling notifications: 
+Once you have defined an action group, you can reference it when scheduling notifications:
 
 ```js
 cordova.plugins.notification.local.schedule({
@@ -263,7 +264,7 @@ The properties depend on the trigger type. Not all of them are supported across 
 
 | Type         | Property      | Type    | Value            | Android | iOS | Windows |
 | :----------- | :------------ | :------ | :--------------- | :------ | :-- | :------ |
-| Fix          | 
+| Fix          |
 |              | at            | Date    |                  | x       | x   | x       |
 | Timespan     |
 |              | in            | Int     |                  | x       | x   | x       |
@@ -433,7 +434,7 @@ To unsubscribe from events:
 cordova.plugins.notification.local.un(event, callback, scope);
 ```
 
-__Note:__ You have to provide the exact same callback to `cordova.plugins.notification.local.un` as you provided to `cordova.plugins.notification.local.on` to make unsubscribing work.  
+__Note:__ You have to provide the exact same callback to `cordova.plugins.notification.local.un` as you provided to `cordova.plugins.notification.local.on` to make unsubscribing work.
 Hence you should define your callback as a separate function, not inline. If you want to use `this` inside of your callback, you also have to provide `this` as `scope` to `cordova.plugins.notification.local.on`.
 
 ### Custom
@@ -474,7 +475,7 @@ document.addEventListener('deviceready', function () {
 
 It might be possible that the underlying framework like __Ionic__ is not compatible with the launch process defined by cordova. With the result that the plugin fires the click event on app start before the app is able to listen for the events.
 
-Therefore its possible to fire the queued events manually by defining a global variable. 
+Therefore its possible to fire the queued events manually by defining a global variable.
 
 ```js
 window.skipLocalNotificationReady = true

--- a/src/android/notification/Builder.java
+++ b/src/android/notification/Builder.java
@@ -31,6 +31,13 @@ import android.support.v4.app.NotificationCompat;
 import android.support.v4.app.NotificationCompat.MessagingStyle.Message;
 import android.support.v4.media.app.NotificationCompat.MediaStyle;
 import android.support.v4.media.session.MediaSessionCompat;
+import android.graphics.Color;
+import android.graphics.PorterDuff;
+import android.graphics.PorterDuffXfermode;
+import android.graphics.Rect;
+import android.graphics.RectF;
+import android.graphics.Paint;
+import android.graphics.Canvas;
 
 import java.util.List;
 import java.util.Random;
@@ -156,7 +163,14 @@ public final class Builder {
 
         if (options.hasLargeIcon()) {
             builder.setSmallIcon(options.getSmallIcon());
-            builder.setLargeIcon(options.getLargeIcon());
+
+            Bitmap largeIcon = options.getLargeIcon();
+
+            if (options.getLargeIconType().equals("circle")) {
+                largeIcon = getCircleBitmap(largeIcon);
+            }
+
+            builder.setLargeIcon(largeIcon);
         } else {
             builder.setSmallIcon(options.getSmallIcon());
         }
@@ -167,6 +181,42 @@ public final class Builder {
         applyContentReceiver(builder);
 
         return new Notification(context, options, builder);
+    }
+
+    /**
+     * Convert a bitmap to a circular bitmap.
+     * This code has been extracted from the Phonegap Plugin Push plugin:
+     * https://github.com/phonegap/phonegap-plugin-push
+     *
+     * @param bitmap Bitmap to convert.
+     * @return Circular bitmap.
+     */
+    private Bitmap getCircleBitmap(Bitmap bitmap) {
+        if (bitmap == null) {
+            return null;
+        }
+
+        final Bitmap output = Bitmap.createBitmap(bitmap.getWidth(), bitmap.getHeight(), Bitmap.Config.ARGB_8888);
+        final Canvas canvas = new Canvas(output);
+        final int color = Color.RED;
+        final Paint paint = new Paint();
+        final Rect rect = new Rect(0, 0, bitmap.getWidth(), bitmap.getHeight());
+        final RectF rectF = new RectF(rect);
+
+        paint.setAntiAlias(true);
+        canvas.drawARGB(0, 0, 0, 0);
+        paint.setColor(color);
+        float cx = bitmap.getWidth() / 2;
+        float cy = bitmap.getHeight() / 2;
+        float radius = cx < cy ? cx : cy;
+        canvas.drawCircle(cx, cy, radius, paint);
+
+        paint.setXfermode(new PorterDuffXfermode(PorterDuff.Mode.SRC_IN));
+        canvas.drawBitmap(bitmap, rect, rect, paint);
+
+        bitmap.recycle();
+
+        return output;
     }
 
     /**

--- a/src/android/notification/Options.java
+++ b/src/android/notification/Options.java
@@ -67,6 +67,9 @@ public final class Options {
     // Default icon path
     private static final String DEFAULT_ICON = "res://icon";
 
+    // Default icon type
+    private static final String DEFAULT_ICON_TYPE = "square";
+
     // The original JSON object
     private final JSONObject options;
 
@@ -371,6 +374,13 @@ public final class Options {
         }
 
         return bmp;
+    }
+
+    /**
+     * Type of the large icon.
+     */
+    String getLargeIconType() {
+        return options.optString("iconType", DEFAULT_ICON_TYPE);
     }
 
     /**

--- a/www/local-notification.js
+++ b/www/local-notification.js
@@ -37,6 +37,7 @@ exports._defaults = {
     group         : null,
     groupSummary  : false,
     icon          : null,
+    iconType      : null,
     id            : 0,
     launch        : true,
     led           : true,


### PR DESCRIPTION
We use the plugin phonegap-push-plugin to receive push notifications when the app is in background. When the app is in foreground, we use this plugin to display a local notification that looks like the push received in background.

The push plugin has an option to convert the icon to a circular bitmap. We've added this feature to this plugin so our notifications can look the same both in foreground and in background.