### PR TITLE
Reuse existing messages when using MessagingStyle

### DIFF
--- a/src/android/notification/Builder.java
+++ b/src/android/notification/Builder.java
@@ -40,6 +40,7 @@ import android.graphics.Paint;
 import android.graphics.Canvas;
 import android.app.NotificationManager;
 import android.service.notification.StatusBarNotification;
+import android.os.Build;
 
 import java.util.List;
 import java.util.Random;
@@ -517,13 +518,16 @@ public final class Builder {
      * @return Notification The active notification, null if not found.
      */
     private android.app.Notification findActiveNotification(Integer notId) {
-        NotificationManager mNotificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
-        StatusBarNotification[] notifications = mNotificationManager.getActiveNotifications();
+        // The getActiveNotifications method is only available from Android M.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            NotificationManager mNotificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+            StatusBarNotification[] notifications = mNotificationManager.getActiveNotifications();
 
-        // Find the notification.
-        for (int i = 0; i < notifications.length; i++) {
-            if (notifications[i].getId() == notId) {
-                return notifications[i].getNotification();
+            // Find the notification.
+            for (int i = 0; i < notifications.length; i++) {
+                if (notifications[i].getId() == notId) {
+                    return notifications[i].getNotification();
+                }
             }
         }
 

--- a/src/android/notification/Notification.java
+++ b/src/android/notification/Notification.java
@@ -324,7 +324,18 @@ public final class Notification {
         }
 
         grantPermissionToPlaySoundFromExternal();
-        getNotMgr().notify(getId(), builder.build());
+        getNotMgr().notify(getAppName(), getId(), builder.build());
+    }
+
+    /**
+     * Get the app name.
+     *
+     * @return String App name.
+     */
+    private String getAppName() {
+        CharSequence appName = context.getPackageManager().getApplicationLabel(context.getApplicationInfo());
+
+        return (String) appName;
     }
 
     /**

--- a/src/android/notification/Options.java
+++ b/src/android/notification/Options.java
@@ -658,6 +658,14 @@ public final class Options {
     }
 
     /**
+     * The message to add to the title to display the number of messages if there is more than one.
+     * Only if using MessagingStytle.
+     */
+    String getTitleCount() {
+        return options.optString("titleCount", null);
+    }
+
+    /**
      * Gets the token for the specified media session.
      *
      * @return null if there no session.


### PR DESCRIPTION
With this fix, users won't have to cache the messages in their Javascript code, the plugin will automatically check if there is an active notification with that ID and append the new messages to the existing ones. This will only be done when using MessagingStyle.

I decided to initialize the sender as "" instead of "Me" because this way users will be able to implement notifications for private conversations like in Telegram or WhatsApp, where the sender isn't displayed.

I also added the option to append the count of messages to the title, like messaging apps do.

Finally, I'm sending the app name as a tag to the _notify_ call to make this plugin compatible with [phonegap-plugin-push](https://github.com/phonegap/phonegap-plugin-push). Now both plugins will use the same tag, so they'll both be able to append new messages to the same notification when using MessagingStyle (I sent a PR to support MessagingStyle in that plugin).