### PR TITLE
oreo bug fix, no smallIcon set in notification

### DIFF
--- a/src/android/notification/Options.java
+++ b/src/android/notification/Options.java
@@ -385,10 +385,6 @@ public final class Options {
         }
 
         if (resId == 0) {
-            resId = context.getApplicationInfo().icon;
-        }
-
-        if (resId == 0) {
             resId = android.R.drawable.ic_popup_reminder;
         }
 

--- a/src/android/notification/util/AssetUtil.java
+++ b/src/android/notification/util/AssetUtil.java
@@ -248,10 +248,6 @@ public final class AssetUtil {
     public int getResId(String resPath) {
         int resId = getResId(context.getResources(), resPath);
 
-        if (resId == 0) {
-            resId = getResId(Resources.getSystem(), resPath);
-        }
-
         return resId;
     }
 


### PR DESCRIPTION
Fix issue https://github.com/katzer/cordova-plugin-local-notifications/issues/1786 if no smallIcon is set in the notification.
Prevent app crash in android oreo (8.1) tested also on 6.0 physical devices.