### PR TITLE
If args === 0 then 'else if' fails and exec will be called with empty array

### DIFF
--- a/www/local-notification.js
+++ b/www/local-notification.js
@@ -894,12 +894,12 @@ exports._toArray = function (obj) {
  */
 exports._exec = function (action, args, callback, scope) {
     var fn     = this._createCallbackFn(callback, scope),
-        params = [];
+        params;
 
     if (Array.isArray(args)) {
         params = args;
-    } else if (args) {
-        params.push(args);
+    } else {
+        params = [args];
     }
 
     exec(fn, null, 'LocalNotification', action, params);


### PR DESCRIPTION

This causes iOS to crash with 'NSRangeException', reason: '*** -[__NSArrayM objectAtIndex:]: index 0 beyond bounds for empty array'