### PR TITLE
Updated dependency configurations

### DIFF
--- a/src/android/build/localnotification.gradle
+++ b/src/android/build/localnotification.gradle
@@ -28,5 +28,5 @@ if (!project.ext.has('appShortcutBadgerVersion')) {
 }
 
 dependencies {
-    compile "me.leolin:ShortcutBadger:${appShortcutBadgerVersion}@aar"
+    implementation "me.leolin:ShortcutBadger:${appShortcutBadgerVersion}@aar"
 }


### PR DESCRIPTION
WARNING: Configuration 'compile' is obsolete and has been replaced with 'implementation' and 'api'
It will be removed at the end of 2018. For more information see: http://d.android.com/r/tools/update-dependency-configurations.html