### PR TITLE
Use correct authority name

### DIFF
--- a/src/android/notification/util/AssetUtil.java
+++ b/src/android/notification/util/AssetUtil.java
@@ -353,7 +353,7 @@ public final class AssetUtil {
      */
     private Uri getUriFromFile(File file) {
         try {
-            String authority = context.getPackageName() + "localnotifications.provider";
+            String authority = context.getPackageName() + ".localnotifications.provider";
             return AssetProvider.getUriForFile(context, authority, file);
         } catch (IllegalArgumentException e) {
             e.printStackTrace();


### PR DESCRIPTION
To match provider config in plugins.xml

Fixes #1664