### PR TITLE
Fix for Samsung too many alarms issue.

### DIFF
--- a/src/android/notification/Notification.java
+++ b/src/android/notification/Notification.java
@@ -45,6 +45,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
+import de.appplant.cordova.plugin.localnotification.TriggerReceiver;
+
 import static android.app.AlarmManager.RTC;
 import static android.app.AlarmManager.RTC_WAKEUP;
 import static android.app.PendingIntent.FLAG_CANCEL_CURRENT;
@@ -88,6 +90,9 @@ public final class Notification {
 
     // Builder with full configuration
     private final NotificationCompat.Builder builder;
+
+    // Receiver to handle the trigger event
+    private Class<?> receiver = TriggerReceiver.class;
 
     /**
      * Constructor
@@ -176,6 +181,8 @@ public final class Notification {
         List<Pair<Date, Intent>> intents = new ArrayList<Pair<Date, Intent>>();
         Set<String> ids                  = new ArraySet<String>();
         AlarmManager mgr                 = getAlarmMgr();
+
+        this.receiver = receiver;
 
         cancelScheduledAlarms();
 
@@ -302,7 +309,8 @@ public final class Notification {
             return;
 
         for (String action : actions) {
-            Intent intent = new Intent(action);
+            Intent intent = new Intent(context, this.receiver)
+                    .setAction(action);
 
             PendingIntent pi = PendingIntent.getBroadcast(
                     context, 0, intent, 0);
@@ -336,6 +344,8 @@ public final class Notification {
     void update (JSONObject updates, Class<?> receiver) {
         mergeJSONObjects(updates);
         persist(null);
+
+        this.receiver = receiver;
 
         if (getType() != Type.TRIGGERED)
             return;


### PR DESCRIPTION
Fixes "too many alarms (500)" issue on Samsung devices after cancelling and scheduling notifications (#1753 and #1701).

Creating the an Intent, when cancelling an existing notification, that matches the one that was used to schedule the notification. This cancels both the PendingIntent and the scheduled Alarm and prevents cancelled scheduled alarms from building up.
See: https://developer.android.com/reference/android/app/AlarmManager?hl=en#cancel(android.app.PendingIntent)
and https://developer.android.com/reference/android/content/Intent.html?hl=en#filterEquals(android.content.Intent)

Samsung has a 500 cap on alarms scheduled from the same uid. Cancelling notifications removed the PendingIntent, but not the Alarm (can be confirmed using the `adb shell dumpsys alarm` command). This could fill the list of alarms from the app with alarms that can't trigger, causing new notifications to be blocked from being scheduled.

The `adb shell dumpsys alarm` command can be used to confirm that the number of alarms from your app decrease appropriately after cancelling scheduled notifications. If updating, to be able to schedule new notifications, your app will have to be force stopped from the settings to remove any existing notifications that did not get cleared properly.