### PR TITLE
Fix trigger json object null object reference

### DIFF
--- a/src/android/notification/Options.java
+++ b/src/android/notification/Options.java
@@ -173,7 +173,12 @@ public final class Options {
      * Gets the raw trigger spec as provided by the user.
      */
     public JSONObject getTrigger() {
-        return options.optJSONObject("trigger");
+        JSONObject triggerObject = options.optJSONObject("trigger");
+
+        if (triggerObject == null)
+          return new JSONObject();
+
+        return triggerObject;
     }
 
     /**


### PR DESCRIPTION
If the "trigger" spec is not provided in the payload, a null object reference is thrown from Request.java from the constructor. This will make sure the trigger spec object is at least an empty json object when it is not provided