### PR TITLE
Check for webView nullability when accessing the WeakReference

### DIFF
--- a/src/android/LocalNotification.java
+++ b/src/android/LocalNotification.java
@@ -714,17 +714,19 @@ public class LocalNotification extends CordovaPlugin {
         }
 
         final CordovaWebView view = webView.get();
+        
+        if (view != null) {
+            ((Activity) (view.getContext())).runOnUiThread(new Runnable() {
+                public void run() {
+                    view.loadUrl("javascript:" + js);
+                    View engineView = view.getEngine().getView();
 
-        ((Activity) (view.getContext())).runOnUiThread(new Runnable() {
-            public void run() {
-                view.loadUrl("javascript:" + js);
-                View engineView = view.getEngine().getView();
-
-                if (!isInForeground()) {
-                    engineView.dispatchWindowVisibilityChanged(View.VISIBLE);
+                    if (!isInForeground()) {
+                        engineView.dispatchWindowVisibilityChanged(View.VISIBLE);
+                    }
                 }
-            }
-        });
+            });
+        }
     }
 
     /**
@@ -737,6 +739,10 @@ public class LocalNotification extends CordovaPlugin {
 
         CordovaWebView view = webView.get();
 
+        if (view == null) {
+            return false;
+        }
+        
         KeyguardManager km = (KeyguardManager) view.getContext().getSystemService(Context.KEYGUARD_SERVICE);
 
         // noinspection SimplifiableIfStatement


### PR DESCRIPTION
The WeakReference allows the underlying object to be garbage collected, and we should check it before use. This resolves a NullPointerException we received from the play store

https://github.com/katzer/cordova-plugin-local-notifications/issues/2013