### PR TITLE
Revert "Migrate to Gradle implementation"

### DIFF
--- a/src/android/build/localnotification.gradle
+++ b/src/android/build/localnotification.gradle
@@ -28,5 +28,5 @@ if (!project.ext.has('appShortcutBadgerVersion')) {
 }
 
 dependencies {
-    implementation "me.leolin:ShortcutBadger:${appShortcutBadgerVersion}@aar"
+    compile "me.leolin:ShortcutBadger:${appShortcutBadgerVersion}@aar"
 }


### PR DESCRIPTION
Reverts katzer/cordova-plugin-local-notifications#1979

This Plugin needs a fresh restart. The fork https://github.com/moodlemobile/cordova-plugin-local-notification contains all necessary changes to make this Plugin work again. From there, we can build up everything again.