### PR TITLE
Revert "Update localnotification.gradle"

### DIFF
--- a/src/android/build/localnotification.gradle
+++ b/src/android/build/localnotification.gradle
@@ -24,7 +24,7 @@ repositories {
 }
 
 if (!project.ext.has('appShortcutBadgerVersion')) {
-    ext.appShortcutBadgerVersion = '1.1.22'
+    ext.appShortcutBadgerVersion = '1.1.19'
 }
 
 dependencies {


### PR DESCRIPTION
Reverts katzer/cordova-plugin-local-notifications#1973

This Plugin needs a fresh restart. The fork https://github.com/moodlemobile/cordova-plugin-local-notification contains all necessary changes to make this Plugin work again. From there, we can build up everything again.