### PR TITLE
(android) bugfix: catch any exceptions when attempting to get option

### DIFF
--- a/src/android/notification/Manager.java
+++ b/src/android/notification/Manager.java
@@ -352,18 +352,19 @@ public final class Manager {
      * @return null if could not found.
      */
     public Options getOptions(int id) {
-        SharedPreferences prefs = getPrefs();
-        String toastId          = Integer.toString(id);
-
-        if (!prefs.contains(toastId))
-            return null;
 
         try {
+            SharedPreferences prefs = getPrefs();
+            String toastId          = Integer.toString(id);
+
+            if (!prefs.contains(toastId))
+                return null;
+
             String json     = prefs.getString(toastId, null);
             JSONObject dict = new JSONObject(json);
 
             return new Options(context, dict);
-        } catch (JSONException e) {
+        } catch (Exception e) {
             e.printStackTrace();
             return null;
         }


### PR DESCRIPTION
to prevent crash:

```
Fatal Exception: java.lang.NullPointerException: Attempt to invoke virtual method 'int java.lang.String.length()' on a null object reference
       at org.json.JSONTokener.nextCleanInternal(JSONTokener.java:121)
       ...
       at de.appplant.cordova.plugin.notification.Manager.getOptions(Manager.java:391)
```