### PR TITLE
Protect against application wide crashes when notification is null.

### DIFF
--- a/src/android/receiver/ClearReceiver.java
+++ b/src/android/receiver/ClearReceiver.java
@@ -26,6 +26,7 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
+import android.util.Log;
 
 import de.appplant.cordova.plugin.localnotification.Notification;
 

--- a/src/android/receiver/ClearReceiver.java
+++ b/src/android/receiver/ClearReceiver.java
@@ -43,9 +43,24 @@ public class ClearReceiver extends BroadcastReceiver {
      */
     @Override
     public void onReceive(Context context, Intent intent) {
-        Notification notification = Notification.getFromSharedPreferences(context, intent.getExtras().getInt(Notification.EXTRA_ID));
+        try {
+            if (intent == null || intent.getExtras() == null) {
+                return; // No action, can't proceed safely
+            }
 
-        // Will remove the notification from SharedPreferences if it is the last one
-        notification.clear();
+            int notificationId = intent.getExtras().getInt(Notification.EXTRA_ID, -1);
+
+            Notification notification = Notification.getFromSharedPreferences(context, notificationId);
+
+            if (notification == null) {
+                Log.w("ClearReceiver", "No notification found in SharedPreferences for ID: " + notificationId);
+                return;
+            }
+
+            // Will remove the notification from SharedPreferences if it is the last one
+            notification.clear();
+        } catch (Exception e) {
+            Log.e("ClearReceiver", "Error processing clear notification intent", e);
+        }
     }
 }

--- a/src/android/receiver/TriggerReceiver.java
+++ b/src/android/receiver/TriggerReceiver.java
@@ -46,20 +46,23 @@ public class TriggerReceiver extends BroadcastReceiver {
      */
     @Override
     public void onReceive(Context context, Intent intent) {
-        Log.d(TAG, "Received action: " + intent.getAction());
+        Log.d(TAG, "Received action: " + (intent != null ? intent.getAction() : "null"));
 
-        Notification notification = Notification.getFromSharedPreferences(
-            context, intent.getExtras().getInt(Notification.EXTRA_ID, 0));
+        if (intent == null || intent.getExtras() == null) {
+            Log.e(TAG, "Intent or extras is null");
+            return;
+        }
 
-        // Show the notification
+        int notificationId = intent.getExtras().getInt(Notification.EXTRA_ID, -1);
+        Notification notification = Notification.getFromSharedPreferences(context, notificationId);
+
+        if (notification == null) {
+            Log.e(TAG, "Notification not found in shared preferences for ID: " + notificationId);
+            return;
+        }
+
+        // Safe to use now
         notification.show(false);
-
-        // Schedule next notification if available. The notification
-        // will not be removed from the SharedPreferences, if there is no
-        // next trigger. So the NotificationClickActivity
-        // and ClearReceiver can still read the notification data. They
-        // will remove the notification from the SharedPreferences if they are
-        // executed. A notification can ony be cleared or clicked.
         notification.scheduleNext();
     }
 }


### PR DESCRIPTION
This should protect against both of the following Android ANRs we are currently seeing:

de.appplant.cordova.plugin.localnotification.receiver.ClearReceiver.onReceive
java.lang.NullPointerException


de.appplant.cordova.plugin.localnotification.receiver.TriggerReceiver.onReceive
java.lang.NullPointerException

